### PR TITLE
[#5] Feat: SQL 쿼리 로깅을 위한 DataSourceProxyBeanPostProcessor 추가

### DIFF
--- a/src/main/java/soon/springtestutil/config/DataSourceProxyBeanPostProcessor.java
+++ b/src/main/java/soon/springtestutil/config/DataSourceProxyBeanPostProcessor.java
@@ -1,0 +1,72 @@
+package soon.springtestutil.config;
+
+import jakarta.annotation.Nonnull;
+import java.lang.reflect.Method;
+import javax.sql.DataSource;
+import net.ttddyy.dsproxy.listener.ChainListener;
+import net.ttddyy.dsproxy.listener.logging.SLF4JQueryLoggingListener;
+import net.ttddyy.dsproxy.support.ProxyDataSource;
+import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * DataSource 빈을 프록시로 감싸는 BeanPostProcessor입니다.
+ * 이 프로세서는 DataSource 빈이 초기화된 후에 호출되어, SLF4J를 사용하여 쿼리를 로깅하는 ProxyDataSource로 감쌉니다.
+ **/
+@Component
+public class DataSourceProxyBeanPostProcessor implements BeanPostProcessor {
+
+    @Override
+    public Object postProcessAfterInitialization(
+        @Nonnull Object bean,
+        @Nonnull String beanName
+    ) throws BeansException {
+        if (bean instanceof DataSource && !(bean instanceof ProxyDataSource)) {
+            ProxyFactory factory = new ProxyFactory(bean);
+            factory.setProxyTargetClass(true); // 다양한 DataSource 구현체를 지원하기 위해 CGLIB 프록시 사용
+            factory.addAdvice(new ProxyDataSourceInterceptor((DataSource) bean));
+            return factory.getProxy();
+        }
+
+        return bean;
+    }
+
+    /**
+     * 실제 DataSource를 ProxyDataSource로 감싸고, 메서드 호출을 위임합니다.
+     */
+    private record ProxyDataSourceInterceptor(DataSource dataSource) implements MethodInterceptor {
+
+        private ProxyDataSourceInterceptor(DataSource dataSource) {
+            ChainListener listener = new ChainListener();
+            listener.addListener(new SLF4JQueryLoggingListener());
+
+            this.dataSource = ProxyDataSourceBuilder.create(dataSource)
+                .name("DataSource-Proxy")
+                .listener(listener)
+                .build();
+        }
+
+        @Override
+        public Object invoke(MethodInvocation invocation) throws Throwable {
+            // 실제 DataSource의 메소드를 프록시 DataSource에서 호출
+            Method proxyMethod = ReflectionUtils.findMethod(
+                dataSource.getClass(),
+                invocation.getMethod().getName(),
+                invocation.getMethod().getParameterTypes()
+            );
+            if (proxyMethod != null) {
+                // 프록시 객체에 메서드가 존재하면 해당 메서드를 호출
+                return proxyMethod.invoke(dataSource, invocation.getArguments());
+            }
+            return invocation.proceed();
+        }
+
+    }
+
+}

--- a/src/test/java/soon/springtestutil/config/DataSourceProxyBeanPostProcessorTest.java
+++ b/src/test/java/soon/springtestutil/config/DataSourceProxyBeanPostProcessorTest.java
@@ -1,0 +1,110 @@
+package soon.springtestutil.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.sql.Connection;
+import javax.sql.DataSource;
+import net.ttddyy.dsproxy.support.ProxyDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.aop.support.AopUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DataSourceProxyBeanPostProcessorTest {
+
+    private DataSourceProxyBeanPostProcessor processor;
+
+    @Mock
+    private DataSource mockDataSource;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private ProxyDataSource mockProxyDataSource;
+
+    @Mock
+    private Connection mockConnection;
+
+    @BeforeEach
+    void setUp() {
+        processor = new DataSourceProxyBeanPostProcessor();
+    }
+
+    @DisplayName("DataSoruce가 아닌 빈은 프록시하지 않고 원본 빈을 반환한다.")
+    @Test
+    void nonDataSourceBeanShouldReturnOriginalBean() {
+        // given
+        Object nonDataSourceBean = new Object();
+        String beanName = "ObjectBean";
+
+        // when
+        Object processedBean = processor.postProcessAfterInitialization(nonDataSourceBean,
+            beanName);
+
+        // then
+        assertThat(processedBean).isSameAs(nonDataSourceBean);
+    }
+
+    @DisplayName("이미 ProxyDayaSource 타입의 빈은 프록시 하지 않고 원본 빈을 반환한다.")
+    @Test
+    void alreadyProxyDataSourceShouldReturnOriginalBean() {
+        // given
+        String beanName = "alreadyProxyDataSourceBean";
+
+        // when
+        Object processedBean = processor.postProcessAfterInitialization(mockProxyDataSource, beanName);
+
+        // then
+        assertThat(processedBean).isSameAs(mockProxyDataSource);
+    }
+
+    @DisplayName("일반 DataSource 빈은 프록시로 감싸서 반환한다.")
+    @Test
+    void dataSourceBeanShouldReturnProxyBean() {
+        // given
+        String beanName = "dataSourceBean";
+
+        // when
+        Object processedBean = processor.postProcessAfterInitialization(mockDataSource, beanName);
+
+        // then
+        assertThat(processedBean)
+            .isNotSameAs(mockDataSource)
+            .isInstanceOf(DataSource.class);
+
+        // setProxyTargetClass(true)로 CGLIB 프록시를 사용하므로
+        assertThat(AopUtils.isCglibProxy(processedBean)).isTrue();
+        assertThat(AopUtils.isAopProxy(processedBean)).isTrue();
+    }
+
+    @DisplayName("프록시된 DataSource의 getConnection 호출 시 프록시의 getConnection이 호출된다.")
+    @Test
+    void getConnectionShouldDelegateToProxy() throws Exception {
+        // given
+        String beanName = "dataSourceBeanWithConnection";
+
+        given(mockDataSource.getConnection())
+            .willReturn(mockConnection);
+
+        // when
+        DataSource proxiedDataSource = (DataSource) processor.postProcessAfterInitialization(mockDataSource, beanName);
+
+        // then
+        assertThat(proxiedDataSource)
+            .isNotNull()
+            .isNotSameAs(mockDataSource);
+
+        Connection connection = proxiedDataSource.getConnection();
+        assertThat(connection)
+            .isNotNull()
+            .isNotSameAs(mockConnection);
+
+        then(mockDataSource).should().getConnection();
+    }
+
+}


### PR DESCRIPTION
## Pull Request

### Related Issue
- Resolved: #5 

### Summary
datasource-proxy를 사용하여 실행되는 SQL 쿼리를 로깅하는 기본 설정을 추가
<!-- 어던 변경을 했는지 작성 -->

### Details
- 스프링내의 모든 DataSource 빈에 대해 자동으로 SQL 쿼리 로깅 기능을 적용하는 클래스 생성
- DataSource 빈을 datasource-proxy로 매핑
<!-- 변경 사항을 구체적으로 작성 -->


### ETC

<!-- 기타 참고사항 작성 -->
