### PR TITLE
[#9] Feat: 쿼리 카운트 검증을 위한 Assertion 클래스 및 테스트 추가

### DIFF
--- a/src/main/java/soon/springtestutil/querycount/QueryCounterAssertion.java
+++ b/src/main/java/soon/springtestutil/querycount/QueryCounterAssertion.java
@@ -1,0 +1,73 @@
+package soon.springtestutil.querycount;
+
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class QueryCounterAssertion {
+
+    private final Map<QueryType, Long> expectedCounts;
+
+    private QueryCounterAssertion() {
+        this.expectedCounts = new EnumMap<>(QueryType.class);
+        for (QueryType type : QueryType.values()) {
+            this.expectedCounts.put(type, 0L);
+        }
+    }
+
+    public static QueryCounterAssertion assertCounts() {
+        return new QueryCounterAssertion();
+    }
+
+    public QueryCounterAssertion select(long count) {
+        expectedCounts.put(QueryType.SELECT, count);
+        return this;
+    }
+
+    public QueryCounterAssertion insert(long count) {
+        expectedCounts.put(QueryType.INSERT, count);
+        return this;
+    }
+
+    public QueryCounterAssertion update(long count) {
+        expectedCounts.put(QueryType.UPDATE, count);
+        return this;
+    }
+
+    public QueryCounterAssertion delete(long count) {
+        expectedCounts.put(QueryType.DELETE, count);
+        return this;
+    }
+
+    public QueryCounterAssertion others(long count) {
+        expectedCounts.put(QueryType.OTHERS, count);
+        return this;
+    }
+
+    public void verify() {
+        EnumMap<QueryType, Long> actualCounts = QueryCountContext.getQueryCounts();
+
+        String errors = Arrays.stream(QueryType.values())
+            .map(type -> {
+                long expected = expectedCounts.getOrDefault(type, 0L);
+                long actual = actualCounts.getOrDefault(type, 0L);
+                if (expected != actual) {
+                    return String.format("QueryType.%s: expected %d, but was %d", type, expected,
+                        actual);
+                }
+                return null;
+            })
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining("\n"));
+
+        if (!errors.isEmpty()) {
+            QueryCountContext.clear();
+            throw new AssertionError("Query count assertion failed:\n" + errors);
+        }
+
+        QueryCountContext.clear();
+    }
+
+}

--- a/src/test/java/soon/springtestutil/querycount/QueryCounterAssertionTest.java
+++ b/src/test/java/soon/springtestutil/querycount/QueryCounterAssertionTest.java
@@ -1,0 +1,63 @@
+package soon.springtestutil.querycount;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class QueryCounterAssertionTest {
+
+    @AfterEach
+    void tearDown() {
+        QueryCountContext.clear();
+    }
+
+    @DisplayName("쿼리 횟수가 예상과 일치하면 예외를 발생하지 않는다.")
+    @Test
+    void verifyShouldPassWhenCountMatch() {
+        // given
+        QueryCountContext.increment(QueryType.SELECT);
+        QueryCountContext.increment(QueryType.SELECT);
+        QueryCountContext.increment(QueryType.INSERT);
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .select(2)
+            .insert(1)
+            .verify();
+    }
+
+    @DisplayName("쿼리 횟수가 예상과 일치하지 않는다면 예외가 발생한다.")
+    @Test
+    void verifyShouldFailWhenCountsDoNotMatch() {
+        // given
+        QueryCountContext.increment(QueryType.SELECT);
+        QueryCountContext.increment(QueryType.INSERT);
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .select(2)
+            .insert(1)
+            .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Query count assertion failed")
+            .hasMessageContaining("QueryType.SELECT: expected 2, but was 1");
+    }
+
+    @Test
+    @DisplayName("쿼리 횟수가 설정되지 않은 경우 기본값인 0으로 검증한다.")
+    void verifyShouldDefaultToZeroForUnsetQueryTypes() {
+        // given
+        QueryCountContext.increment(QueryType.SELECT);
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .insert(1)
+            .verify())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("QueryType.INSERT: expected 1, but was 0");
+    }
+
+}


### PR DESCRIPTION
## Pull Request

### Related Issue
- Resolved: #9 

### Summary
SQL 쿼리 유형별 횟수를 검증하기 위한 유틸 클래스 구현
<!-- 어던 변경을 했는지 작성 -->

### Details
테스트 코드에서 실행된 SQL 쿼리 유형별 횟수를 검증하기 위한 유틸리티 클래스 QueryCounterAssertion을 구현
이 클래스는 체이닝 방식을 통해 구현
<!-- 변경 사항을 구체적으로 작성 -->


### ETC

<!-- 기타 참고사항 작성 -->
