### PR TITLE
[#11] Refactor: 쿼리 카운트 오류 메시지에 클래스명 및 메서드명 포함

### DIFF
--- a/src/main/java/soon/springtestutil/querycount/QueryCountListener.java
+++ b/src/main/java/soon/springtestutil/querycount/QueryCountListener.java
@@ -26,8 +26,12 @@ public class QueryCountListener implements QueryExecutionListener {
                     QueryType queryType = queryTypeCache.computeIfAbsent(sql, QueryType::from);
                     QueryCountContext.increment(queryType);
                 } catch (IllegalArgumentException e) {
-                    log.warn("Cannot determine query type for: [{}]. Error: {}", sql,
-                        e.getMessage());
+                    String contextInfo = TestContextHolder.getContextInfo();
+                    log.warn("{}Cannot determine query type for: [{}]. Error: {}",
+                        contextInfo,
+                        sql,
+                        e.getMessage()
+                    );
                 }
             }
         }

--- a/src/main/java/soon/springtestutil/querycount/QueryCountTestExtension.java
+++ b/src/main/java/soon/springtestutil/querycount/QueryCountTestExtension.java
@@ -1,0 +1,21 @@
+package soon.springtestutil.querycount;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class QueryCountTestExtension implements BeforeEachCallback, AfterEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        String className = context.getRequiredTestClass().getName();
+        String methodName = context.getRequiredTestMethod().getName();
+        TestContextHolder.setContext(className, methodName);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        TestContextHolder.clearContext();
+    }
+
+}

--- a/src/main/java/soon/springtestutil/querycount/QueryCounterAssertion.java
+++ b/src/main/java/soon/springtestutil/querycount/QueryCounterAssertion.java
@@ -64,7 +64,9 @@ public class QueryCounterAssertion {
 
         if (!errors.isEmpty()) {
             QueryCountContext.clear();
-            throw new AssertionError("Query count assertion failed:\n" + errors);
+
+            String contextInfo = TestContextHolder.getContextInfo();
+            throw new AssertionError(contextInfo + "Query count assertion failed:\n" + errors);
         }
 
         QueryCountContext.clear();

--- a/src/main/java/soon/springtestutil/querycount/TestContextHolder.java
+++ b/src/main/java/soon/springtestutil/querycount/TestContextHolder.java
@@ -1,0 +1,32 @@
+package soon.springtestutil.querycount;
+
+import lombok.Getter;
+
+@Getter
+public class TestContextHolder {
+
+    private static final ThreadLocal<String> testClassNameHolder = new ThreadLocal<>();
+    private static final ThreadLocal<String> testMethodNameHolder = new ThreadLocal<>();
+
+    public static void setContext(String className, String methodName) {
+        testClassNameHolder.set(className);
+        testMethodNameHolder.set(methodName);
+    }
+
+    public static String getContextInfo() {
+        String className = testClassNameHolder.get();
+        String methodName = testMethodNameHolder.get();
+
+        if (className != null && methodName != null) {
+            return String.format("[Test: %s#%s]", className, methodName);
+        }
+
+        return "[Test: Unknown]";
+    }
+
+    public static void clearContext() {
+        testClassNameHolder.remove();
+        testMethodNameHolder.remove();
+    }
+
+}

--- a/src/test/java/soon/springtestutil/querycount/QueryCounterAssertionTest.java
+++ b/src/test/java/soon/springtestutil/querycount/QueryCounterAssertionTest.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(QueryCountTestExtension.class)
 class QueryCounterAssertionTest {
 
     @AfterEach
@@ -42,8 +44,10 @@ class QueryCounterAssertionTest {
             .verify()
         )
             .isInstanceOf(AssertionError.class)
-            .hasMessageContaining("Query count assertion failed")
-            .hasMessageContaining("QueryType.SELECT: expected 2, but was 1");
+            .hasMessage(
+                """
+                    [Test: soon.springtestutil.querycount.QueryCounterAssertionTest#verifyShouldFailWhenCountsDoNotMatch]Query count assertion failed:
+                    QueryType.SELECT: expected 2, but was 1""");
     }
 
     @Test
@@ -57,7 +61,11 @@ class QueryCounterAssertionTest {
             .insert(1)
             .verify())
             .isInstanceOf(AssertionError.class)
-            .hasMessageContaining("QueryType.INSERT: expected 1, but was 0");
+            .hasMessage(
+                """
+                    [Test: soon.springtestutil.querycount.QueryCounterAssertionTest#verifyShouldDefaultToZeroForUnsetQueryTypes]Query count assertion failed:
+                    QueryType.SELECT: expected 0, but was 1
+                    QueryType.INSERT: expected 1, but was 0""");
     }
 
 }

--- a/src/test/java/soon/springtestutil/querycount/TestContextHolderTest.java
+++ b/src/test/java/soon/springtestutil/querycount/TestContextHolderTest.java
@@ -1,0 +1,91 @@
+package soon.springtestutil.querycount;
+
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TestContextHolderTest {
+
+    @AfterEach
+    void tearDown() {
+        TestContextHolder.clearContext();
+    }
+
+    @DisplayName("테스트 컨텍스트 정보를 조회한다.")
+    @Test
+    void contextInfoSelected() {
+        // given
+        String className = "com.example.TestContextHolderTest";
+        String methodName = "contextInfoSelected";
+        String expected = "[Test: %s#%s]".formatted(className, methodName);
+
+        // when
+        TestContextHolder.setContext(className, methodName);
+
+        // then
+        String contextInfo = TestContextHolder.getContextInfo();
+        assertThat(contextInfo)
+            .isEqualTo(expected);
+    }
+
+    @DisplayName("컨텍스트 정보가 설정되지 않은 경우 Unknown이 반환된다.")
+    @Test
+    void contextInfoReturnsUnknownWhenNotSet() {
+        // given
+        String contextInfo = TestContextHolder.getContextInfo();
+
+        // expected
+        assertThat(contextInfo)
+            .isEqualTo("[Test: Unknown]");
+    }
+
+    @DisplayName("여러 스레드에서 컨텍스트 정보는 격리된다.")
+    @Test
+    void contextInfoIsThreadSpecific() throws InterruptedException {
+        // given
+        ExecutorService executorService = newFixedThreadPool(2);
+        CountDownLatch latch = new CountDownLatch(2);
+
+        String thread1ClassName = "com.example.Thread1Test";
+        String thread1MethodName = "thread1Method";
+        String thread2ClassName = "com.example.Thread2Test";
+        String thread2MethodName = "thread2Method";
+
+        // excepted
+        executorService.submit(() -> {
+            try {
+                TestContextHolder.setContext(thread1ClassName, thread1MethodName);
+                String contextInfo = TestContextHolder.getContextInfo();
+
+                assertThat(contextInfo)
+                    .isEqualTo("[Test: %s#%s]".formatted(thread1ClassName, thread1MethodName));
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        executorService.submit(() -> {
+            try {
+                TestContextHolder.setContext(thread2ClassName, thread2MethodName);
+                String contextInfo = TestContextHolder.getContextInfo();
+
+                assertThat(contextInfo)
+                    .isEqualTo("[Test: %s#%s]".formatted(thread2ClassName, thread2MethodName));
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        latch.await();
+        executorService.shutdown();
+
+        assertThat(TestContextHolder.getContextInfo())
+            .isEqualTo("[Test: Unknown]");
+    }
+
+}


### PR DESCRIPTION
## Pull Request

### Related Issue
- Resolved: #11 

### Summary
테스트 실패 시 어떤 테스트에서 실패했는지 명확하게 확인하기 위해 오류 메시지 수정
<!-- 어던 변경을 했는지 작성 -->

### Details
쿼리 카운트 실패로 AssertionError 발생 시 오류 메시지에 클래스명 및 메서드명 포함
<!-- 변경 사항을 구체적으로 작성 -->


### ETC

<!-- 기타 참고사항 작성 -->
