### PR TITLE
[#34] Fix: 명시하지 않은 쿼리까지 검증 되는 문제 해결

### DIFF
--- a/src/main/java/soon/springtestutil/querycount/assertion/QueryCounterAssertion.java
+++ b/src/main/java/soon/springtestutil/querycount/assertion/QueryCounterAssertion.java
@@ -1,13 +1,12 @@
 package soon.springtestutil.querycount.assertion;
 
-import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import soon.springtestutil.core.context.TestContextHolder;
-import soon.springtestutil.querycount.context.QueryCountContext;
 import soon.springtestutil.querycount.QueryType;
+import soon.springtestutil.querycount.context.QueryCountContext;
 
 public class QueryCounterAssertion {
 
@@ -15,9 +14,6 @@ public class QueryCounterAssertion {
 
     private QueryCounterAssertion() {
         this.expectedCounts = new EnumMap<>(QueryType.class);
-        for (QueryType type : QueryType.values()) {
-            this.expectedCounts.put(type, 0L);
-        }
     }
 
     public static QueryCounterAssertion assertCounts() {
@@ -52,9 +48,9 @@ public class QueryCounterAssertion {
     public void verify() {
         EnumMap<QueryType, Long> actualCounts = QueryCountContext.getQueryCounts();
 
-        String errors = Arrays.stream(QueryType.values())
+        String errors = expectedCounts.keySet().stream()
             .map(type -> {
-                long expected = expectedCounts.getOrDefault(type, 0L);
+                long expected = expectedCounts.get(type);
                 long actual = actualCounts.getOrDefault(type, 0L);
                 if (expected != actual) {
                     return String.format("QueryType.%s: expected %d, but was %d", type, expected,

--- a/src/test/java/soon/springtestutil/querycount/assertion/QueryCounterAssertionTest.java
+++ b/src/test/java/soon/springtestutil/querycount/assertion/QueryCounterAssertionTest.java
@@ -53,9 +53,39 @@ class QueryCounterAssertionTest {
                     QueryType.SELECT: expected 2, but was 1""");
     }
 
+    @DisplayName("지정하지 않은 쿼리 타입은 검증하지 않는다.")
     @Test
-    @DisplayName("쿼리 횟수가 설정되지 않은 경우 기본값인 0으로 검증한다.")
-    void verifyShouldDefaultToZeroForUnsetQueryTypes() {
+    void verifyShouldIgnoreUnspecifiedTypes() {
+        // given
+        QueryCountContext.increment(QueryType.SELECT);
+        QueryCountContext.increment(QueryType.INSERT);
+        QueryCountContext.increment(QueryType.INSERT);
+        QueryCountContext.increment(QueryType.UPDATE);
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .select(1)
+            .verify();
+    }
+
+    @DisplayName("여러 타입 중 일부만 지정하면, 지정한 타입만 검증한다.")
+    @Test
+    void verifyShouldCheckOnlySpecifiedTypes() {
+        // given
+        QueryCountContext.increment(QueryType.SELECT);
+        QueryCountContext.increment(QueryType.INSERT);
+        QueryCountContext.increment(QueryType.INSERT);
+        QueryCountContext.increment(QueryType.UPDATE);
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .insert(2)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("지정하지 않은 타입은 무시하고, 지정한 타입만 검증한다.")
+    void verifyShouldOnlyCheckSpecifiedType() {
         // given
         QueryCountContext.increment(QueryType.SELECT);
 
@@ -66,8 +96,7 @@ class QueryCounterAssertionTest {
             .isInstanceOf(AssertionError.class)
             .hasMessage(
                 """
-                    [Test: soon.springtestutil.querycount.assertion.QueryCounterAssertionTest#verifyShouldDefaultToZeroForUnsetQueryTypes]Query count assertion failed:
-                    QueryType.SELECT: expected 0, but was 1
+                    [Test: soon.springtestutil.querycount.assertion.QueryCounterAssertionTest#verifyShouldOnlyCheckSpecifiedType]Query count assertion failed:
                     QueryType.INSERT: expected 1, but was 0""");
     }
 


### PR DESCRIPTION
## Pull Request

### Related Issue
- Resolved: #34 

### Summary
create 쿼리와 같이 검증하지 않는 쿼리에 대해서도 others로 지정하지 않으면 테스트가 통과하지 않는 문제 해결
<!-- 어던 변경을 했는지 작성 -->

### Details
QueryCounterAssertion 클래스에서 모든 쿼리 타입에 대한 검증이 아닌 명시한 쿼리 타입에 대해서만 검증
<!-- 변경 사항을 구체적으로 작성 -->

### ETC

<!-- 기타 참고사항 작성 -->
