### PR TITLE
[#36] Feat: 특정 테이블에 대해서만 쿼리 수 검증 기능 추가

### DIFF
--- a/src/main/java/soon/springtestutil/querycount/assertion/QueryCounterAssertion.java
+++ b/src/main/java/soon/springtestutil/querycount/assertion/QueryCounterAssertion.java
@@ -1,16 +1,23 @@
 package soon.springtestutil.querycount.assertion;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import soon.springtestutil.core.context.TestContextHolder;
 import soon.springtestutil.querycount.QueryType;
 import soon.springtestutil.querycount.context.QueryCountContext;
+import soon.springtestutil.querycount.context.QueryInfo;
 
 public class QueryCounterAssertion {
 
     private final Map<QueryType, Long> expectedCounts;
+    private Set<String> tableNames;
 
     private QueryCounterAssertion() {
         this.expectedCounts = new EnumMap<>(QueryType.class);
@@ -18,6 +25,16 @@ public class QueryCounterAssertion {
 
     public static QueryCounterAssertion assertCounts() {
         return new QueryCounterAssertion();
+    }
+
+    public QueryCounterAssertion forTables(String... tableNames) {
+        this.tableNames = new HashSet<>(Arrays.asList(tableNames)); // new HashSet
+        return this;
+    }
+
+    public QueryCounterAssertion forTables(List<String> tableNames) {
+        this.tableNames = new HashSet<>(tableNames);
+        return this;
     }
 
     public QueryCounterAssertion select(long count) {
@@ -46,7 +63,7 @@ public class QueryCounterAssertion {
     }
 
     public void verify() {
-        EnumMap<QueryType, Long> actualCounts = QueryCountContext.getQueryCounts();
+        EnumMap<QueryType, Long> actualCounts = getActualCounts();
 
         String errors = expectedCounts.keySet().stream()
             .map(type -> {
@@ -69,6 +86,19 @@ public class QueryCounterAssertion {
         }
 
         QueryCountContext.clear();
+    }
+
+    private EnumMap<QueryType, Long> getActualCounts() {
+        if (tableNames == null || tableNames.isEmpty()) {
+            return QueryCountContext.getQueryCounts();
+        }
+        return QueryCountContext.getQueries().stream()
+            .filter(queryInfo -> !Collections.disjoint(queryInfo.getTableNames(), tableNames))
+            .collect(Collectors.groupingBy(
+                QueryInfo::getQueryType,
+                () -> new EnumMap<>(QueryType.class),
+                Collectors.counting()
+            ));
     }
 
 }

--- a/src/main/java/soon/springtestutil/querycount/context/QueryCountContext.java
+++ b/src/main/java/soon/springtestutil/querycount/context/QueryCountContext.java
@@ -1,35 +1,44 @@
 package soon.springtestutil.querycount.context;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.Map;
+import java.util.List;
+import java.util.stream.Collectors;
 import soon.springtestutil.querycount.QueryType;
 
 /**
- * 현재 스레드에서 실행된 쿼리 유형별 횟수를 저장하고 관리하는 유틸리티 클래스입니다.
- * 이 클래스는 {@link ThreadLocal}을 사용하여 각 스레드별로 쿼리 카운트를 격리합니다.
+ * 현재 스레드에서 실행된 쿼리 정보를 저장하고 관리하는 유틸리티 클래스입니다. 이 클래스는 {@link ThreadLocal}을 사용하여 각 스레드별로 쿼리 정보를 격리합니다.
  * 모든 메서드는 정적이며, 인스턴스화할 수 없습니다.
  */
 public final class QueryCountContext {
 
-    private static final ThreadLocal<Map<QueryType, Long>> queryCounts = ThreadLocal.withInitial(
-        () -> new EnumMap<>(QueryType.class)
-    );
+    private static final ThreadLocal<List<QueryInfo>> queries = ThreadLocal
+        .withInitial(ArrayList::new);
 
     private QueryCountContext() {
         throw new UnsupportedOperationException("Utility class");
     }
 
-    public static void increment(QueryType queryType) {
-        queryCounts.get()
-            .compute(queryType, (k, v) -> (v == null) ? 1L : v + 1L);
+    public static void addQuery(QueryType queryType, String query) {
+        queries.get()
+            .add(new QueryInfo(queryType, query));
+    }
+
+    public static List<QueryInfo> getQueries() {
+        return new ArrayList<>(queries.get());
     }
 
     public static EnumMap<QueryType, Long> getQueryCounts() {
-        return new EnumMap<>(queryCounts.get());
+        return queries.get().stream()
+            .collect(Collectors.groupingBy(
+                QueryInfo::getQueryType,
+                () -> new EnumMap<>(QueryType.class),
+                Collectors.counting()
+            ));
     }
 
     public static void clear() {
-        queryCounts.remove();
+        queries.remove();
     }
 
 }

--- a/src/main/java/soon/springtestutil/querycount/context/QueryInfo.java
+++ b/src/main/java/soon/springtestutil/querycount/context/QueryInfo.java
@@ -1,0 +1,37 @@
+package soon.springtestutil.querycount.context;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Getter;
+import soon.springtestutil.querycount.QueryType;
+
+@Getter
+public class QueryInfo {
+
+    private static final Pattern TABLE_NAME_PATTERN = Pattern.compile(
+        "\\b(from|join|into|update|delete\\s+from)\\s+([a-zA-Z0-9_`.\"]+)",
+        Pattern.CASE_INSENSITIVE
+    );
+
+    private final QueryType queryType;
+    private final String query;
+    private final Set<String> tableNames;
+
+    public QueryInfo(QueryType queryType, String query) {
+        this.queryType = queryType;
+        this.query = query;
+        this.tableNames = extractTableNames(query);
+    }
+
+    private Set<String> extractTableNames(String query) {
+        Set<String> names = new LinkedHashSet<>();
+        Matcher matcher = TABLE_NAME_PATTERN.matcher(query);
+        while (matcher.find()) {
+            names.add(matcher.group(2)); // group(1) : keyword, group(2) : table name
+        }
+        return names;
+    }
+
+}

--- a/src/main/java/soon/springtestutil/querycount/datasource/QueryCountListener.java
+++ b/src/main/java/soon/springtestutil/querycount/datasource/QueryCountListener.java
@@ -27,7 +27,7 @@ public class QueryCountListener implements QueryExecutionListener {
             if (sql != null && !sql.trim().isEmpty()) {
                 try {
                     QueryType queryType = queryTypeCache.computeIfAbsent(sql, QueryType::from);
-                    QueryCountContext.increment(queryType);
+                    QueryCountContext.addQuery(queryType, sql);
                 } catch (IllegalArgumentException e) {
                     String contextInfo = TestContextHolder.getContextInfo();
                     log.warn("{}Cannot determine query type for: [{}]. Error: {}",

--- a/src/test/java/soon/springtestutil/querycount/assertion/QueryCounterAssertionTest.java
+++ b/src/test/java/soon/springtestutil/querycount/assertion/QueryCounterAssertionTest.java
@@ -2,6 +2,7 @@ package soon.springtestutil.querycount.assertion;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,12 +23,13 @@ class QueryCounterAssertionTest {
     @Test
     void verifyShouldPassWhenCountMatch() {
         // given
-        QueryCountContext.increment(QueryType.SELECT);
-        QueryCountContext.increment(QueryType.SELECT);
-        QueryCountContext.increment(QueryType.INSERT);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (1, 'test')");
 
         // expected
         QueryCounterAssertion.assertCounts()
+            .forTables("member")
             .select(2)
             .insert(1)
             .verify();
@@ -37,8 +39,8 @@ class QueryCounterAssertionTest {
     @Test
     void verifyShouldFailWhenCountsDoNotMatch() {
         // given
-        QueryCountContext.increment(QueryType.SELECT);
-        QueryCountContext.increment(QueryType.INSERT);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (1, 'test')");
 
         // expected
         assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
@@ -47,20 +49,17 @@ class QueryCounterAssertionTest {
             .verify()
         )
             .isInstanceOf(AssertionError.class)
-            .hasMessage(
-                """
-                    [Test: soon.springtestutil.querycount.assertion.QueryCounterAssertionTest#verifyShouldFailWhenCountsDoNotMatch]Query count assertion failed:
-                    QueryType.SELECT: expected 2, but was 1""");
+            .hasMessageContaining("QueryType.SELECT: expected 2, but was 1");
     }
 
     @DisplayName("지정하지 않은 쿼리 타입은 검증하지 않는다.")
     @Test
     void verifyShouldIgnoreUnspecifiedTypes() {
         // given
-        QueryCountContext.increment(QueryType.SELECT);
-        QueryCountContext.increment(QueryType.INSERT);
-        QueryCountContext.increment(QueryType.INSERT);
-        QueryCountContext.increment(QueryType.UPDATE);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (1, 'test')");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (2, 'test2')");
+        QueryCountContext.addQuery(QueryType.UPDATE, "UPDATE member SET name = 'test' WHERE id = 1");
 
         // expected
         QueryCounterAssertion.assertCounts()
@@ -72,10 +71,10 @@ class QueryCounterAssertionTest {
     @Test
     void verifyShouldCheckOnlySpecifiedTypes() {
         // given
-        QueryCountContext.increment(QueryType.SELECT);
-        QueryCountContext.increment(QueryType.INSERT);
-        QueryCountContext.increment(QueryType.INSERT);
-        QueryCountContext.increment(QueryType.UPDATE);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (1, 'test')");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (2, 'test2')");
+        QueryCountContext.addQuery(QueryType.UPDATE, "UPDATE member SET name = 'test' WHERE id = 1");
 
         // expected
         QueryCounterAssertion.assertCounts()
@@ -87,17 +86,65 @@ class QueryCounterAssertionTest {
     @DisplayName("지정하지 않은 타입은 무시하고, 지정한 타입만 검증한다.")
     void verifyShouldOnlyCheckSpecifiedType() {
         // given
-        QueryCountContext.increment(QueryType.SELECT);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
 
         // expected
         assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
             .insert(1)
             .verify())
             .isInstanceOf(AssertionError.class)
-            .hasMessage(
-                """
-                    [Test: soon.springtestutil.querycount.assertion.QueryCounterAssertionTest#verifyShouldOnlyCheckSpecifiedType]Query count assertion failed:
-                    QueryType.INSERT: expected 1, but was 0""");
+            .hasMessageContaining("QueryType.INSERT: expected 1, but was 0");
+    }
+
+    @Test
+    @DisplayName("forTables로 지정된 테이블의 쿼리만 검증한다.")
+    void verifyShouldCheckOnlySpecifiedTables() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM orders");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (1, 'test')");
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .forTables("member")
+            .select(1)
+            .insert(1)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("forTables로 지정된 테이블의 쿼리만 검증한다.")
+    void verifyShouldCheckOnlySpecifiedTablesWithList() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM product");
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT m.name, o.order_date FROM member m JOIN orders o ON m.id = o.member_id");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (1, 'test')");
+        QueryCountContext.addQuery(QueryType.UPDATE, "UPDATE product SET name = 'test' WHERE id = 1");
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .forTables(List.of("member", "orders"))
+            .select(2)
+            .insert(1)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("forTables로 지정된 테이블의 쿼리 횟수가 다르면 예외가 발생한다.")
+    void verifyShouldFailWhenCountsDoNotMatchForSpecifiedTables() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM orders");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (1, 'test')");
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .forTables("member")
+            .select(2)
+            .verify())
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("QueryType.SELECT: expected 2, but was 1");
     }
 
 }

--- a/src/test/java/soon/springtestutil/querycount/context/QueryCountContextTest.java
+++ b/src/test/java/soon/springtestutil/querycount/context/QueryCountContextTest.java
@@ -30,28 +30,30 @@ class QueryCountContextTest {
     }
 
     @Test
-    @DisplayName("쿼리 유형을 증가시키면 해당 유형의 카운트가 증가한다")
-    void incrementOnceShouldUpdateCount() {
+    @DisplayName("쿼리 정보를 추가하면 해당 유형의 카운트가 증가한다")
+    void addQueryOnceShouldUpdateCount() {
         // given
         QueryType queryType = QueryType.SELECT;
+        String query = "SELECT * FROM member";
 
         // when
-        QueryCountContext.increment(queryType);
+        QueryCountContext.addQuery(queryType, query);
         Map<QueryType, Long> counts = QueryCountContext.getQueryCounts();
 
         // then
         assertThat(counts).containsEntry(queryType, 1L);
     }
 
-    @DisplayName("동일한 쿼리 유형을 여러 번 증가시키면 해당 유형의 카운트만 누적된다.")
+    @DisplayName("동일한 쿼리 유형을 여러 번 추가하면 해당 유형의 카운트만 누적된다.")
     @Test
-    void incrementMultipleTimesShouldUpdateCountCorrectly() {
+    void addQueryMultipleTimesShouldUpdateCountCorrectly() {
         // given
         QueryType queryType = QueryType.SELECT;
+        String query = "SELECT * FROM member";
 
         // when
         for (int i = 0; i < 5; i++) {
-            QueryCountContext.increment(queryType);
+            QueryCountContext.addQuery(queryType, query);
         }
 
         // then
@@ -59,32 +61,31 @@ class QueryCountContextTest {
         assertThat(counts).containsEntry(queryType, 5L);
     }
 
-    @DisplayName("다른 쿼리 유형을 증가시키면 해당 유형의 카운트가 별도로 유지된다.")
+    @DisplayName("다른 쿼리 유형을 추가하면 해당 유형의 카운트가 별도로 유지된다.")
     @Test
-    void incrementDifferentQueryTypesShouldMaintainSeparateCounts() {
+    void addQueryDifferentQueryTypesShouldMaintainSeparateCounts() {
         // given
         QueryType selectType = QueryType.SELECT;
+        String selectQuery = "SELECT * FROM member";
         QueryType insertType = QueryType.INSERT;
+        String insertQuery = "INSERT INTO member (id, name) VALUES (1, 'test')";
 
         // when
-        QueryCountContext.increment(selectType);
-        QueryCountContext.increment(insertType);
-        Map<QueryType, Long> counts = QueryCountContext.getQueryCounts();
+        QueryCountContext.addQuery(selectType, selectQuery);
+        QueryCountContext.addQuery(insertType, insertQuery);
 
         // then
+        Map<QueryType, Long> counts = QueryCountContext.getQueryCounts();
         assertThat(counts).containsEntry(selectType, 1L);
         assertThat(counts).containsEntry(insertType, 1L);
     }
 
-    @DisplayName("클리어 호출 시 쿼리 카운트가 초기화 된다.")
+    @DisplayName("쿼리 정보를 초기화하면 모든 카운트가 0이 된다.")
     @Test
-    void clearShouldResetQueryCounts() {
+    void clearShouldResetAllQueries() {
         // given
-        QueryType selectType = QueryType.SELECT;
-        QueryType insertType = QueryType.INSERT;
-
-        QueryCountContext.increment(selectType);
-        QueryCountContext.increment(insertType);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (1, 'test')");
 
         // when
         QueryCountContext.clear();
@@ -120,8 +121,8 @@ class QueryCountContextTest {
         // when
         executorService.submit(() -> {
             try {
-                QueryCountContext.increment(selectType);
-                QueryCountContext.increment(selectType);
+                QueryCountContext.addQuery(selectType, "SELECT 1");
+                QueryCountContext.addQuery(selectType, "SELECT 2");
                 assertThat(QueryCountContext.getQueryCounts())
                     .isEqualTo(Map.of(selectType, 2L));
             } finally {
@@ -132,9 +133,9 @@ class QueryCountContextTest {
 
         executorService.submit(() -> {
             try {
-                QueryCountContext.increment(insertType);
-                QueryCountContext.increment(updateType);
-                QueryCountContext.increment(insertType);
+                QueryCountContext.addQuery(insertType, "INSERT 1");
+                QueryCountContext.addQuery(updateType, "UPDATE 1");
+                QueryCountContext.addQuery(insertType, "INSERT 2");
                 assertThat(QueryCountContext.getQueryCounts())
                     .isEqualTo(Map.of(insertType, 2L, updateType, 1L));
             } finally {


### PR DESCRIPTION
## Pull Request

### Related Issue
- Resolved: #36 

### Summary
현재는 실행 중인 모든 쿼리에 대해 검증이 이뤄지지만, 특정 테이블에 대해서만 쿼리 수를 검증할 수 있도록 기능을 개선
<!-- 어던 변경을 했는지 작성 -->

### Details
- QueryCounterAssertion 클래스 수정
- QueryCountContext 클래스 수정
- QueryCountListener 클래스 수정
- QueryInfo 클래스 추가
- 테스트 코드 추가 및 수정
<!-- 변경 사항을 구체적으로 작성 -->


### ETC

<!-- 기타 참고사항 작성 -->
