### PR TITLE
[#40] Fix: 각 테스트 실행 전후로 QueryCountContext를 초기화

### DIFF
--- a/src/main/java/soon/springtestutil/querycount/extension/QueryCountTestExtension.java
+++ b/src/main/java/soon/springtestutil/querycount/extension/QueryCountTestExtension.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import soon.springtestutil.core.context.TestContextHolder;
+import soon.springtestutil.querycount.context.QueryCountContext;
 
 public class QueryCountTestExtension implements BeforeEachCallback, AfterEachCallback {
 
@@ -12,11 +13,15 @@ public class QueryCountTestExtension implements BeforeEachCallback, AfterEachCal
         String className = context.getRequiredTestClass().getName();
         String methodName = context.getRequiredTestMethod().getName();
         TestContextHolder.setContext(className, methodName);
+
+        QueryCountContext.clear();
     }
 
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
         TestContextHolder.clearContext();
+
+        QueryCountContext.clear();
     }
 
 }


### PR DESCRIPTION
## Pull Request

### Related Issue
- Resolved: #40 

### Summary
전체 테스트를 한번에 실행하는 등 여러 테스트를 한번에 실행 하는 경우 쿼리 카운트의 각 테스트 별 격리가 깨지는 문제 해결
<!-- 어던 변경을 했는지 작성 -->

### Details
QueryCountTestExtension 클래스의 beforeEach, afterEach 메서드에 Context clear 추가
<!-- 변경 사항을 구체적으로 작성 -->


### ETC

<!-- 기타 참고사항 작성 -->
