### PR TITLE
[#42] Feat: 쿼리 실행 시간 검증 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    testImplementation 'com.h2database:h2'
+
 }
 
 bootJar {

--- a/src/main/java/soon/springtestutil/querycount/assertion/QueryCounterAssertion.java
+++ b/src/main/java/soon/springtestutil/querycount/assertion/QueryCounterAssertion.java
@@ -1,26 +1,20 @@
 package soon.springtestutil.querycount.assertion;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 import soon.springtestutil.core.context.TestContextHolder;
 import soon.springtestutil.querycount.QueryType;
 import soon.springtestutil.querycount.context.QueryCountContext;
 import soon.springtestutil.querycount.context.QueryInfo;
 
+import java.util.*;
+import java.util.stream.Collectors;
+
 public class QueryCounterAssertion {
 
-    private final Map<QueryType, Long> expectedCounts;
+    private final Map<QueryType, Long> expectedCounts = new EnumMap<>(QueryType.class);
     private Set<String> tableNames;
+    private Long maxExecutionTimeMs;
 
     private QueryCounterAssertion() {
-        this.expectedCounts = new EnumMap<>(QueryType.class);
     }
 
     public static QueryCounterAssertion assertCounts() {
@@ -28,7 +22,7 @@ public class QueryCounterAssertion {
     }
 
     public QueryCounterAssertion forTables(String... tableNames) {
-        this.tableNames = new HashSet<>(Arrays.asList(tableNames)); // new HashSet
+        this.tableNames = new HashSet<>(Arrays.asList(tableNames));
         return this;
     }
 
@@ -62,6 +56,12 @@ public class QueryCounterAssertion {
         return this;
     }
 
+    // TODO: 현재는 각 쿼리별 측정, 통합 실행 시간 측정 기능 추가
+    public QueryCounterAssertion maxExecutionTimeMs(long maxExecutionTimeMs) {
+        this.maxExecutionTimeMs = maxExecutionTimeMs;
+        return this;
+    }
+
     public void verify() {
         EnumMap<QueryType, Long> actualCounts = getActualCounts();
 
@@ -85,6 +85,30 @@ public class QueryCounterAssertion {
             throw new AssertionError(contextInfo + "Query count assertion failed:\n" + errors);
         }
 
+        if (maxExecutionTimeMs != null) {
+            List<QueryInfo> filtered = getFilteredQueriesForTimeCheck();
+            List<QueryInfo> violations = filtered.stream()
+                .filter(q -> q.getExecutionTimeMs() != null && q.getExecutionTimeMs() > maxExecutionTimeMs)
+                .toList();
+
+            if (!violations.isEmpty()) {
+                QueryInfo first = violations.get(0);
+                String contextInfo = TestContextHolder.getContextInfo();
+                QueryCountContext.clear();
+                String message = String.format(
+                    "%sQuery execution time assertion failed: max=%dms, violations=%d\nFirst violation: %dms > %dms, type=%s\nSQL: %s",
+                    contextInfo,
+                    maxExecutionTimeMs,
+                    violations.size(),
+                    first.getExecutionTimeMs(),
+                    maxExecutionTimeMs,
+                    first.getQueryType(),
+                    first.getQuery()
+                );
+                throw new AssertionError(message);
+            }
+        }
+
         QueryCountContext.clear();
     }
 
@@ -99,6 +123,24 @@ public class QueryCounterAssertion {
                 () -> new EnumMap<>(QueryType.class),
                 Collectors.counting()
             ));
+    }
+
+    private List<QueryInfo> getFilteredQueriesForTimeCheck() {
+        List<QueryInfo> base = QueryCountContext.getQueries();
+        if (tableNames != null && !tableNames.isEmpty()) {
+            base = base.stream()
+                .filter(q -> !Collections.disjoint(q.getTableNames(), tableNames))
+                .collect(Collectors.toList());
+        }
+
+        if (!expectedCounts.isEmpty()) {
+            Set<QueryType> types = expectedCounts.keySet();
+            base = base.stream()
+                .filter(q -> types.contains(q.getQueryType()))
+                .collect(Collectors.toList());
+        }
+
+        return base;
     }
 
 }

--- a/src/main/java/soon/springtestutil/querycount/context/QueryCountContext.java
+++ b/src/main/java/soon/springtestutil/querycount/context/QueryCountContext.java
@@ -1,10 +1,11 @@
 package soon.springtestutil.querycount.context;
 
+import soon.springtestutil.querycount.QueryType;
+
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.stream.Collectors;
-import soon.springtestutil.querycount.QueryType;
 
 /**
  * 현재 스레드에서 실행된 쿼리 정보를 저장하고 관리하는 유틸리티 클래스입니다. 이 클래스는 {@link ThreadLocal}을 사용하여 각 스레드별로 쿼리 정보를 격리합니다.
@@ -22,6 +23,11 @@ public final class QueryCountContext {
     public static void addQuery(QueryType queryType, String query) {
         queries.get()
             .add(new QueryInfo(queryType, query));
+    }
+
+    public static void addQuery(QueryType queryType, String query, Long executionTimeMs) {
+        queries.get()
+            .add(new QueryInfo(queryType, query, executionTimeMs));
     }
 
     public static List<QueryInfo> getQueries() {

--- a/src/main/java/soon/springtestutil/querycount/context/QueryInfo.java
+++ b/src/main/java/soon/springtestutil/querycount/context/QueryInfo.java
@@ -1,11 +1,12 @@
 package soon.springtestutil.querycount.context;
 
+import lombok.Getter;
+import soon.springtestutil.querycount.QueryType;
+
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.Getter;
-import soon.springtestutil.querycount.QueryType;
 
 @Getter
 public class QueryInfo {
@@ -18,11 +19,17 @@ public class QueryInfo {
     private final QueryType queryType;
     private final String query;
     private final Set<String> tableNames;
+    private final Long executionTimeMs;
 
     public QueryInfo(QueryType queryType, String query) {
+        this(queryType, query, null);
+    }
+
+    public QueryInfo(QueryType queryType, String query, Long executionTimeMs) {
         this.queryType = queryType;
         this.query = query;
         this.tableNames = extractTableNames(query);
+        this.executionTimeMs = executionTimeMs;
     }
 
     private Set<String> extractTableNames(String query) {

--- a/src/main/java/soon/springtestutil/querycount/datasource/QueryCountListener.java
+++ b/src/main/java/soon/springtestutil/querycount/datasource/QueryCountListener.java
@@ -1,8 +1,5 @@
 package soon.springtestutil.querycount.datasource;
 
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import lombok.extern.slf4j.Slf4j;
 import net.ttddyy.dsproxy.ExecutionInfo;
 import net.ttddyy.dsproxy.QueryInfo;
@@ -10,6 +7,10 @@ import net.ttddyy.dsproxy.listener.QueryExecutionListener;
 import soon.springtestutil.core.context.TestContextHolder;
 import soon.springtestutil.querycount.QueryType;
 import soon.springtestutil.querycount.context.QueryCountContext;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 @Slf4j
 public class QueryCountListener implements QueryExecutionListener {
@@ -22,12 +23,21 @@ public class QueryCountListener implements QueryExecutionListener {
 
     @Override
     public void afterQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+        Long elapsedMs = null;
+        try {
+            if (execInfo != null) {
+                elapsedMs = execInfo.getElapsedTime();
+            }
+        } catch (Exception e) {
+            log.debug("Failed to get elapsed time from ExecutionInfo: {}", e.getMessage());
+        }
+
         for (QueryInfo queryInfo : queryInfoList) {
             String sql = queryInfo.getQuery();
             if (sql != null && !sql.trim().isEmpty()) {
                 try {
                     QueryType queryType = queryTypeCache.computeIfAbsent(sql, QueryType::from);
-                    QueryCountContext.addQuery(queryType, sql);
+                    QueryCountContext.addQuery(queryType, sql, elapsedMs);
                 } catch (IllegalArgumentException e) {
                     String contextInfo = TestContextHolder.getContextInfo();
                     log.warn("{}Cannot determine query type for: [{}]. Error: {}",

--- a/src/test/java/soon/springtestutil/querycount/assertion/QueryCountAssertionIntegrationTest.java
+++ b/src/test/java/soon/springtestutil/querycount/assertion/QueryCountAssertionIntegrationTest.java
@@ -1,0 +1,133 @@
+package soon.springtestutil.querycount.assertion;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import soon.springtestutil.config.AutoConfig;
+import soon.springtestutil.querycount.QueryType;
+import soon.springtestutil.querycount.context.QueryCountContext;
+import soon.springtestutil.querycount.extension.QueryCountTestExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@EnableAutoConfiguration
+@SpringBootTest(classes = AutoConfig.class)
+@ExtendWith(QueryCountTestExtension.class)
+public class QueryCountAssertionIntegrationTest {
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void tearDown() {
+        QueryCountContext.clear();
+    }
+
+    @BeforeEach
+    void initSchema() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS orders");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS member");
+        jdbcTemplate.execute("CREATE TABLE member (id INT PRIMARY KEY, name VARCHAR(100))");
+        jdbcTemplate.execute("CREATE TABLE orders (id INT PRIMARY KEY, member_id INT, amount INT)");
+        jdbcTemplate.execute("CREATE ALIAS IF NOT EXISTS SLEEP FOR \"java.lang.Thread.sleep\"");
+        QueryCountContext.clear();
+    }
+
+    @Test
+    @DisplayName("SELECT 카운트가 예상과 일치한다.")
+    void verifySelectCountSuccess() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 20L);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 25L);
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .select(2)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("여러 테이블 지정시 지정된 테이블 관련 쿼리만 카운트된다")
+    void multipleTablesFiltering() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 30L);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM orders", 40L);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT m.id, o.id FROM member m JOIN orders o ON m.id = o.member_id", 50L);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM product", 35L); // 제외
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .forTables("member", "orders")
+            .select(3)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("개별 쿼리 실행 시간이 한도를 초과하면 실패한다")
+    void failsWhenPerQueryExecutionTimeExceeded() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 120L);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 80L);
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .maxExecutionTimeMs(100)
+            .select(2)
+            .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Query execution time assertion failed")
+            .hasMessageContaining("violations=");
+    }
+
+    @Test
+    @DisplayName("예상 카운트와 실제 카운트가 다르면 실패한다")
+    void failsWhenCountMismatch() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 10L);
+
+        // expected
+        assertThatThrownBy(() ->
+            QueryCounterAssertion.assertCounts()
+                .select(2)
+                .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("expected 2, but was 1");
+    }
+
+    @Test
+    @DisplayName("maxExecutionTime(ms)를 초과한 쿼리는 실패한다")
+    void verifyMaxExecutionTimeShouldFailWhenExceeded() {
+        // given
+        jdbcTemplate.execute("CALL SLEEP(120)");
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .maxExecutionTimeMs(50)
+            .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Query execution time assertion failed")
+            .hasMessageContaining("violations=");
+    }
+
+    @Test
+    @DisplayName("maxExecutionTimeMs 미사용 시 카운트 검증만 수행된다")
+    void countOnlyUnaffectedWithoutMaxTime() {
+        // given
+        jdbcTemplate.queryForObject("SELECT 1", Integer.class);
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .select(1)
+            .verify();
+    }
+
+}

--- a/src/test/java/soon/springtestutil/querycount/assertion/QueryCounterAssertionTest.java
+++ b/src/test/java/soon/springtestutil/querycount/assertion/QueryCounterAssertionTest.java
@@ -1,8 +1,5 @@
 package soon.springtestutil.querycount.assertion;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +7,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import soon.springtestutil.querycount.QueryType;
 import soon.springtestutil.querycount.context.QueryCountContext;
 import soon.springtestutil.querycount.extension.QueryCountTestExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(QueryCountTestExtension.class)
 class QueryCounterAssertionTest {
@@ -145,6 +146,69 @@ class QueryCounterAssertionTest {
             .verify())
             .isInstanceOf(AssertionError.class)
             .hasMessageContaining("QueryType.SELECT: expected 2, but was 1");
+    }
+
+    @Test
+    @DisplayName("쿼리 실행 시간이 maxExecutionTimeMs 이하이면 통과한다.")
+    void verifyShouldPassWhenExecutionTimeWithinLimit() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 50L);
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (1, 'test')", 80L);
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .maxExecutionTimeMs(100)
+            .select(1)
+            .insert(1)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("쿼리 실행 시간이 maxExecutionTimeMs를 초과하면 예외가 발생한다.")
+    void verifyShouldFailWhenExecutionTimeExceedsLimit() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 150L);
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .maxExecutionTimeMs(100)
+            .select(1)
+            .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Query execution time assertion failed");
+    }
+
+    @Test
+    @DisplayName("실행 시간이 null인 쿼리는 maxExecutionTimeMs 검증에서 무시된다.")
+    void verifyShouldIgnoreQueriesWithoutExecutionTime() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (1, 'test')", 50L);
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .maxExecutionTimeMs(100)
+            .select(1)
+            .insert(1)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("forTables로 여러 테이블을 지정하면 해당 모든 테이블의 쿼리가 실행 시간/카운트 검증에 포함된다.")
+    void verifyShouldIncludeExecutionTimeFromAllSpecifiedTables() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 50L);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM orders", 60L);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT m.name, o.id FROM member m JOIN orders o ON m.id = o.member_id", 90L);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM product", 40L); // 필터에서 제외
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .forTables("member", "orders")
+            .maxExecutionTimeMs(100)
+            .select(3)
+            .verify();
     }
 
 }

--- a/src/test/java/soon/springtestutil/querycount/context/QueryCountContextTest.java
+++ b/src/test/java/soon/springtestutil/querycount/context/QueryCountContextTest.java
@@ -1,16 +1,19 @@
 package soon.springtestutil.querycount.context;
 
-import static java.util.concurrent.Executors.newFixedThreadPool;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.EnumMap;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import soon.springtestutil.querycount.QueryType;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 class QueryCountContextTest {
 
@@ -158,6 +161,27 @@ class QueryCountContextTest {
 
         // then
         assertThat(QueryCountContext.getQueryCounts()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("쿼리를 실행 시간과 함께 추가하면 QueryInfo에 저장된다.")
+    void addQueryWithExecutionTimeShouldStoreExecutionTime() {
+        // given
+        QueryType queryType = QueryType.SELECT;
+        String query = "SELECT * FROM member";
+        long executionTimeMs = 123L;
+
+        // when
+        QueryCountContext.addQuery(queryType, query, executionTimeMs);
+
+        // then
+        List<QueryInfo> queries = QueryCountContext.getQueries();
+        assertThat(queries).hasSize(1)
+            .extracting("queryType", "query", "executionTimeMs")
+            .containsExactly(tuple(queryType, query, executionTimeMs));
+
+        Map<QueryType, Long> counts = QueryCountContext.getQueryCounts();
+        assertThat(counts).containsEntry(queryType, 1L);
     }
 
 }

--- a/src/test/java/soon/springtestutil/querycount/context/QueryInfoTest.java
+++ b/src/test/java/soon/springtestutil/querycount/context/QueryInfoTest.java
@@ -1,0 +1,126 @@
+package soon.springtestutil.querycount.context;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import soon.springtestutil.querycount.QueryType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QueryInfoTest {
+
+    @DisplayName("SELECT 구문에서 테이블 명을 추출한다.")
+    @Test
+    void extractTableName() {
+        // given
+        String sql = "SELECT * FROM member";
+
+        // when
+        QueryInfo info = new QueryInfo(QueryType.SELECT, sql);
+
+        // then
+        assertThat(info.getTableNames()).containsExactly("member");
+    }
+
+    @Test
+    @DisplayName("같은 테이블 명이 반복되어도 한 번만 포함된다")
+    void duplicateTableNamesAreDeduplicated() {
+        // given
+        String sql = "SELECT * FROM member m JOIN member m2 ON m.id = m2.ref_id";
+
+        // when
+        QueryInfo info = new QueryInfo(QueryType.SELECT, sql);
+
+        // then
+        assertThat(info.getTableNames()).containsExactly("member");
+    }
+
+    @Test
+    @DisplayName("백틱 또는 따옴표로 감싼 테이블명을 추출한다")
+    void extractQuotedTableName() {
+        // given
+        String sql1 = "INSERT INTO `member` (id) VALUES (1)";
+        String sql2 = "SELECT * FROM \"MemberTable\"";
+        String sql3 = "UPDATE `schema`.`member` SET name=?";
+
+        // when
+        QueryInfo info1 = new QueryInfo(QueryType.INSERT, sql1);
+        QueryInfo info2 = new QueryInfo(QueryType.SELECT, sql2);
+        QueryInfo info3 = new QueryInfo(QueryType.UPDATE, sql3);
+
+        // then
+        assertThat(info1.getTableNames()).containsExactly("`member`");
+        assertThat(info2.getTableNames()).containsExactly("\"MemberTable\"");
+        assertThat(info3.getTableNames()).containsExactly("`schema`.`member`");
+    }
+
+    @Test
+    @DisplayName("DELETE 구문에서 테이블명을 추출한다")
+    void extractTableNameFromDelete() {
+        // given
+        String sql = "DELETE FROM member WHERE id=?";
+
+        // when
+        QueryInfo info = new QueryInfo(QueryType.DELETE, sql);
+
+        // then
+        assertThat(info.getTableNames()).containsExactly("member");
+    }
+
+    @Test
+    @DisplayName("대소문자 혼합 키워드에서도 테이블명을 추출한다")
+    void extractTableNamesCaseInsensitive() {
+        // given
+        String sql = "select * FrOm Member m JoIn Orders o ON m.id=o.mid";
+
+        // when
+        QueryInfo info = new QueryInfo(QueryType.SELECT, sql);
+
+        // then
+        assertThat(info.getTableNames()).containsExactly("Member", "Orders");
+    }
+
+    @Test
+    @DisplayName("매칭되는 키워드가 없으면 테이블명 집합은 비어 있다")
+    void emptyTableNamesWhenNoKeywords() {
+        // given
+        String sql = "SELECT 1";
+
+        // when
+        QueryInfo info = new QueryInfo(QueryType.SELECT, sql);
+
+        // then
+        assertThat(info.getTableNames()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기본 생성자를 사용하면 executionTimeMs는 null이다")
+    void executionTimeIsNullWhenNotProvided() {
+        // given
+        String sql = "SELECT * FROM member";
+
+        // when
+        QueryInfo info = new QueryInfo(QueryType.SELECT, sql);
+
+        // then
+        assertThat(info.getExecutionTimeMs()).isNull();
+    }
+
+    @Test
+    @DisplayName("여러 구문이 혼합된 SQL에서 모든 대상 테이블을 추출한다")
+    void extractAllTablesFromComplexSql() {
+        // given
+        String sql = """
+            UPDATE orders o
+            JOIN member m ON o.member_id = m.id
+            JOIN product p ON p.id = o.product_id
+            SET o.status='DONE'
+            """;
+
+        // when
+        QueryInfo info = new QueryInfo(QueryType.UPDATE, sql);
+
+        // then
+        assertThat(info.getTableNames()).containsExactly("orders", "member", "product");
+    }
+
+}

--- a/src/test/java/soon/springtestutil/querycount/datasource/QueryCountListenerTest.java
+++ b/src/test/java/soon/springtestutil/querycount/datasource/QueryCountListenerTest.java
@@ -1,12 +1,5 @@
 package soon.springtestutil.querycount.datasource;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import net.ttddyy.dsproxy.ExecutionInfo;
 import net.ttddyy.dsproxy.QueryInfo;
 import org.junit.jupiter.api.AfterEach;
@@ -15,6 +8,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import soon.springtestutil.querycount.QueryType;
 import soon.springtestutil.querycount.context.QueryCountContext;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 class QueryCountListenerTest {
 
@@ -93,6 +94,25 @@ class QueryCountListenerTest {
         // then
         Map<QueryType, Long> counts = QueryCountContext.getQueryCounts();
         assertThat(counts).containsEntry(QueryType.OTHERS, 1L);
+    }
+
+    @DisplayName("동일한 SQL도 실행시간은 각각 저장된다")
+    @Test
+    void elapsedTimeCapturedIndependentlyForCachedQueryType() {
+        // given
+        given(execInfo.getElapsedTime()).willReturn(10L, 22L);
+        QueryInfo q1 = createMockQueryInfo("SELECT * FROM cache_test");
+        QueryInfo q2 = createMockQueryInfo("SELECT * FROM cache_test");
+
+        // when
+        listener.afterQuery(execInfo, List.of(q1));
+        listener.afterQuery(execInfo, List.of(q2));
+
+        // then
+        var stored = QueryCountContext.getQueries();
+        assertThat(stored).hasSize(2)
+            .extracting("executionTimeMs")
+            .containsExactly(10L, 22L);
     }
 
     private QueryInfo createMockQueryInfo(String sql) {


### PR DESCRIPTION
## Pull Request

### Related Issue
- Resolved: #42 

### Summary
각 쿼리 별 최대 수행 시간 지정 후 검증 기능 구현 
<!-- 어던 변경을 했는지 작성 -->

### Details
- QueryInfo에 executionTimeMs 필드 추가 및 기존 생성자와 호환되도록 오버로드 구현
- QueryCountListener에서 쿼리 실행 시간을 측정하여 QueryInfo에 저장
- QueryCounterAssertion에 maxExecutionTime(long maxMs) 메서드 추가
- 지정한 최대 실행 시간을 초과하는 쿼리는 AssertionError 발생
- 기존 기능(쿼리 타입별 카운트, 테이블 필터링, 빌더 타입 API) 유지
- Spring Boot + JUnit 5 테스트와 호환성 확인 (@ExtendWith(QueryCountTestExtension.class))

<!-- 변경 사항을 구체적으로 작성 -->


### ETC

<!-- 기타 참고사항 작성 -->
