### PR TITLE
Refactor: 테이블별 쿼리 횟수 개별 검증 기능 추가 및 DSL 개선

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ---
 
+## [0.0.6] - 2026-01-08
+### Added
+- 테이블별 개별 쿼리 카운트 검증 기능 추가 (`forTable`)
+    - `forTable("member").insert(2).select(1)` 형태로 테이블마다 다른 검증 조건 설정 가능
+    - 여러 테이블에 대해 체이닝으로 각각 다른 조건 설정 가능
+    - 테이블별 `maxExecutionTimeMs` 설정 지원
+- `TableQueryAssertion` 클래스 추가
+
 ## [0.0.5] - 2025-09-11
 ### Added
 - 개별 쿼리 실행 시간(`maxExecutionTimeMs`)을 지정하여 시간 초과 쿼리에 대해 검증할 수 있는 기능 추가

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ class MemberServiceTest {
 
 | 메서드                              | 설명                                            |
   |----------------------------------|-----------------------------------------------|
+| `forTable(String table)`         | 특정 테이블에 대한 쿼리 검증 조건을 개별 설정합니다. 체이닝으로 여러 테이블에 각각 다른 조건 설정 가능 |
 | `forTables(String... tables)`    | 검증할 테이블 이름을 지정합니다. 지정하지 않으면 모든 테이블 쿼리를 검증합니다. |
 | `forTables(List<String> tables)` | 리스트 형태로 검증할 테이블 이름 지정                         |
 | `select(int expected)`           | SELECT 쿼리 실행 횟수 검증                            |
@@ -129,6 +130,42 @@ void updateOrderWithExecutionTimeCheck() {
         .verify();
 }
 
+@Test
+void verifyQueryCountPerTable() {
+    // given
+    Member member = new Member("test");
+    memberRepository.save(member);
+
+    Product product = new Product("item", 1000);
+    productRepository.save(product);
+
+    // when
+    memberService.getMember(member.getId());
+    productService.getProducts();
+
+    // then - 테이블별로 각각 다른 쿼리 수 검증
+    QueryCounterAssertion.assertCounts()
+        .forTable("member").insert(1).select(1)
+        .forTable("product").insert(1).select(1)
+        .verify();
+}
+
+@Test
+void verifyQueryCountPerTableWithExecutionTime() {
+    // given
+    Member member = new Member("test");
+    memberRepository.save(member);
+
+    // when
+    memberService.getMember(member.getId());
+
+    // then - 테이블별 쿼리 수 + 실행 시간 검증
+    QueryCounterAssertion.assertCounts()
+        .forTable("member").insert(1).select(1).maxExecutionTimeMs(100)
+        .forTable("orders").select(2).maxExecutionTimeMs(200)
+        .verify();
+}
+
 ```
 
 ### 예외처리
@@ -144,8 +181,20 @@ QueryType.SELECT: expected 3, but was 2
 ```
 
 ``` text
+java.lang.AssertionError: [Test: {패키지}.{클래스}#{메서드}] Table-specific query count assertion failed:
+Table 'member' - QueryType.SELECT: expected 2, but was 1
+```
+
+``` text
 java.lang.AssertionError: [Test: {패키지}.{클래스}#{메서드}]
 Query execution time assertion failed: max=100ms, violations=1
+First violation: 120ms > 100ms, type=SELECT
+SQL: SELECT * FROM member
+```
+
+``` text
+java.lang.AssertionError: [Test: {패키지}.{클래스}#{메서드}]
+Table 'member' execution time assertion failed: max=100ms, violations=1
 First violation: 120ms > 100ms, type=SELECT
 SQL: SELECT * FROM member
 ```

--- a/src/main/java/soon/springtestutil/config/DataSourceProxyBeanPostProcessor.java
+++ b/src/main/java/soon/springtestutil/config/DataSourceProxyBeanPostProcessor.java
@@ -1,8 +1,6 @@
 package soon.springtestutil.config;
 
 import jakarta.annotation.Nonnull;
-import java.lang.reflect.Method;
-import javax.sql.DataSource;
 import net.ttddyy.dsproxy.listener.ChainListener;
 import net.ttddyy.dsproxy.listener.logging.SLF4JQueryLoggingListener;
 import net.ttddyy.dsproxy.support.ProxyDataSource;
@@ -15,6 +13,9 @@ import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ReflectionUtils;
 import soon.springtestutil.querycount.datasource.QueryCountListener;
+
+import javax.sql.DataSource;
+import java.lang.reflect.Method;
 
 /**
  * DataSource 빈을 프록시로 감싸는 BeanPostProcessor입니다.

--- a/src/main/java/soon/springtestutil/core/context/TestContextHolder.java
+++ b/src/main/java/soon/springtestutil/core/context/TestContextHolder.java
@@ -1,8 +1,5 @@
 package soon.springtestutil.core.context;
 
-import lombok.Getter;
-
-@Getter
 public class TestContextHolder {
 
     private static final ThreadLocal<String> testClassNameHolder = new ThreadLocal<>();
@@ -18,10 +15,10 @@ public class TestContextHolder {
         String methodName = testMethodNameHolder.get();
 
         if (className != null && methodName != null) {
-            return String.format("[Test: %s#%s]", className, methodName);
+            return String.format("[Test: %s#%s] ", className, methodName);
         }
 
-        return "[Test: Unknown]";
+        return "";
     }
 
     public static void clearContext() {

--- a/src/main/java/soon/springtestutil/querycount/assertion/QueryCountVerifier.java
+++ b/src/main/java/soon/springtestutil/querycount/assertion/QueryCountVerifier.java
@@ -103,11 +103,15 @@ class QueryCountVerifier {
                 Collectors.counting()
             ));
 
-        return expected.entrySet().stream()
-            .filter(entry -> !entry.getValue().equals(actualCounts.getOrDefault(entry.getKey(), 0L)))
-            .map(entry -> String.format("Table '%s' - QueryType.%s: expected %d, but was %d",
-                tableName, entry.getKey(), entry.getValue(), actualCounts.getOrDefault(entry.getKey(), 0L)))
-            .collect(Collectors.toList());
+        List<String> errors = new ArrayList<>();
+        for (Map.Entry<QueryType, Long> entry : expected.entrySet()) {
+            long actual = actualCounts.getOrDefault(entry.getKey(), 0L);
+            if (!entry.getValue().equals(actual)) {
+                errors.add(String.format("Table '%s' - QueryType.%s: expected %d, but was %d",
+                    tableName, entry.getKey(), entry.getValue(), actual));
+            }
+        }
+        return errors;
     }
 
     private void verifyExecutionTimes() {

--- a/src/main/java/soon/springtestutil/querycount/assertion/QueryCountVerifier.java
+++ b/src/main/java/soon/springtestutil/querycount/assertion/QueryCountVerifier.java
@@ -1,0 +1,209 @@
+package soon.springtestutil.querycount.assertion;
+
+import soon.springtestutil.core.context.TestContextHolder;
+import soon.springtestutil.querycount.QueryType;
+import soon.springtestutil.querycount.context.QueryCountContext;
+import soon.springtestutil.querycount.context.QueryInfo;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 쿼리 카운트 검증을 수행하는 내부 클래스
+ */
+class QueryCountVerifier {
+
+    private final Map<QueryType, Long> expectedCounts;
+    private final Map<String, TableQueryAssertion> tableAssertions;
+    private final Set<String> tableNames;
+    private final Long maxExecutionTimeMs;
+
+    // 캐싱된 쿼리 목록
+    private List<QueryInfo> cachedQueries;
+
+    QueryCountVerifier(
+        Map<QueryType, Long> expectedCounts,
+        Map<String, TableQueryAssertion> tableAssertions,
+        Set<String> tableNames,
+        Long maxExecutionTimeMs
+    ) {
+        this.expectedCounts = expectedCounts;
+        this.tableAssertions = tableAssertions;
+        this.tableNames = tableNames;
+        this.maxExecutionTimeMs = maxExecutionTimeMs;
+    }
+
+    void verify() {
+        this.cachedQueries = QueryCountContext.getQueries();
+
+        List<String> errors = collectErrors();
+
+        if (!errors.isEmpty()) {
+            throw new AssertionError(TestContextHolder.getContextInfo() + String.join("\n\n", errors));
+        }
+
+        verifyExecutionTimes();
+    }
+
+    private List<String> collectErrors() {
+        List<String> errors = new ArrayList<>();
+        verifyQueryCounts(errors);
+        verifyTableQueryCounts(errors);
+        return errors;
+    }
+
+    private void verifyQueryCounts(List<String> errors) {
+        if (expectedCounts.isEmpty()) {
+            return;
+        }
+
+        EnumMap<QueryType, Long> actualCounts = getActualCounts();
+        String countErrors = expectedCounts.entrySet().stream()
+            .map(entry -> compareCount(entry.getKey(), entry.getValue(), actualCounts))
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining("\n"));
+
+        if (!countErrors.isEmpty()) {
+            errors.add("Query count assertion failed:\n" + countErrors);
+        }
+    }
+
+    private String compareCount(QueryType type, long expected, Map<QueryType, Long> actual) {
+        long actualCount = actual.getOrDefault(type, 0L);
+        if (expected != actualCount) {
+            return String.format("QueryType.%s: expected %d, but was %d", type, expected, actualCount);
+        }
+        return null;
+    }
+
+    private void verifyTableQueryCounts(List<String> errors) {
+        if (tableAssertions.isEmpty()) {
+            return;
+        }
+
+        List<String> tableErrors = new ArrayList<>();
+        for (TableQueryAssertion tableAssertion : tableAssertions.values()) {
+            tableErrors.addAll(verifyTableAssertion(tableAssertion));
+        }
+
+        if (!tableErrors.isEmpty()) {
+            errors.add("Table-specific query count assertion failed:\n" + String.join("\n", tableErrors));
+        }
+    }
+
+    private List<String> verifyTableAssertion(TableQueryAssertion assertion) {
+        String tableName = assertion.getTableName();
+        Map<QueryType, Long> expected = assertion.getExpectedCounts();
+
+        EnumMap<QueryType, Long> actualCounts = cachedQueries.stream()
+            .filter(q -> q.getTableNames().contains(tableName))
+            .collect(Collectors.groupingBy(
+                QueryInfo::getQueryType,
+                () -> new EnumMap<>(QueryType.class),
+                Collectors.counting()
+            ));
+
+        return expected.entrySet().stream()
+            .filter(entry -> !entry.getValue().equals(actualCounts.getOrDefault(entry.getKey(), 0L)))
+            .map(entry -> String.format("Table '%s' - QueryType.%s: expected %d, but was %d",
+                tableName, entry.getKey(), entry.getValue(), actualCounts.getOrDefault(entry.getKey(), 0L)))
+            .collect(Collectors.toList());
+    }
+
+    private void verifyExecutionTimes() {
+        verifyGlobalExecutionTime();
+        verifyTableExecutionTime();
+    }
+
+    private void verifyGlobalExecutionTime() {
+        if (maxExecutionTimeMs == null) {
+            return;
+        }
+
+        List<QueryInfo> violations = getFilteredQueriesForTimeCheck().stream()
+            .filter(q -> q.getExecutionTimeMs() != null && q.getExecutionTimeMs() > maxExecutionTimeMs)
+            .toList();
+
+        if (!violations.isEmpty()) {
+            throw createExecutionTimeError(violations.get(0), maxExecutionTimeMs, violations.size(), null);
+        }
+    }
+
+    private void verifyTableExecutionTime() {
+
+        for (TableQueryAssertion tableAssertion : tableAssertions.values()) {
+            Long tableMaxTime = tableAssertion.getMaxExecutionTimeMs();
+            if (tableMaxTime == null) {
+                continue;
+            }
+
+            String tableName = tableAssertion.getTableName();
+            Set<QueryType> types = tableAssertion.getExpectedCounts().isEmpty()
+                ? null
+                : tableAssertion.getExpectedCounts().keySet();
+
+            List<QueryInfo> violations = cachedQueries.stream()
+                .filter(q -> q.getTableNames().contains(tableName))
+                .filter(q -> types == null || types.contains(q.getQueryType()))
+                .filter(q -> q.getExecutionTimeMs() != null && q.getExecutionTimeMs() > tableMaxTime)
+                .toList();
+
+            if (!violations.isEmpty()) {
+                throw createExecutionTimeError(violations.get(0), tableMaxTime, violations.size(), tableName);
+            }
+        }
+    }
+
+    private AssertionError createExecutionTimeError(QueryInfo violation, long maxTime, int count, String tableName) {
+        String prefix = tableName != null
+            ? String.format("Table '%s' execution time", tableName)
+            : "Query execution time";
+
+        String message = String.format(
+            "%s%s assertion failed: max=%dms, violations=%d\nFirst violation: %dms > %dms, type=%s\nSQL: %s",
+            TestContextHolder.getContextInfo(),
+            prefix,
+            maxTime,
+            count,
+            violation.getExecutionTimeMs(),
+            maxTime,
+            violation.getQueryType(),
+            violation.getQuery()
+        );
+        return new AssertionError(message);
+    }
+
+    private EnumMap<QueryType, Long> getActualCounts() {
+        if (tableNames == null || tableNames.isEmpty()) {
+            return cachedQueries.stream()
+                .collect(Collectors.groupingBy(
+                    QueryInfo::getQueryType,
+                    () -> new EnumMap<>(QueryType.class),
+                    Collectors.counting()
+                ));
+        }
+        return cachedQueries.stream()
+            .filter(queryInfo -> !Collections.disjoint(queryInfo.getTableNames(), tableNames))
+            .collect(Collectors.groupingBy(
+                QueryInfo::getQueryType,
+                () -> new EnumMap<>(QueryType.class),
+                Collectors.counting()
+            ));
+    }
+
+    private List<QueryInfo> getFilteredQueriesForTimeCheck() {
+        boolean hasTableFilter = tableNames != null && !tableNames.isEmpty();
+        boolean hasTypeFilter = !expectedCounts.isEmpty();
+
+        Set<QueryType> types = hasTypeFilter ? expectedCounts.keySet() : null;
+        if (!hasTableFilter && !hasTypeFilter) {
+            return cachedQueries;
+        }
+
+        return cachedQueries.stream()
+            .filter(q -> !hasTableFilter || !Collections.disjoint(q.getTableNames(), tableNames))
+            .filter(q -> !hasTypeFilter || types.contains(q.getQueryType()))
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/soon/springtestutil/querycount/assertion/QueryCountVerifier.java
+++ b/src/main/java/soon/springtestutil/querycount/assertion/QueryCountVerifier.java
@@ -13,6 +13,8 @@ import java.util.stream.Collectors;
  */
 class QueryCountVerifier {
 
+    private static final int MAX_VIOLATIONS_TO_REPORT = 3;
+
     private final Map<QueryType, Long> expectedCounts;
     private final Map<String, TableQueryAssertion> tableAssertions;
     private final Set<String> tableNames;
@@ -128,7 +130,7 @@ class QueryCountVerifier {
             .toList();
 
         if (!violations.isEmpty()) {
-            errors.add(formatExecutionTimeError(violations.get(0), maxExecutionTimeMs, violations.size(), null));
+            errors.add(formatExecutionTimeError(violations, maxExecutionTimeMs, null));
         }
     }
 
@@ -140,6 +142,8 @@ class QueryCountVerifier {
             }
 
             String tableName = tableAssertion.getTableName();
+
+            // expectedCounts가 비어있으면 해당 테이블의 모든 쿼리 타입을 검사
             Set<QueryType> types = tableAssertion.getExpectedCounts().isEmpty()
                 ? null
                 : tableAssertion.getExpectedCounts().keySet();
@@ -151,26 +155,36 @@ class QueryCountVerifier {
                 .toList();
 
             if (!violations.isEmpty()) {
-                errors.add(formatExecutionTimeError(violations.get(0), tableMaxTime, violations.size(), tableName));
+                errors.add(formatExecutionTimeError(violations, tableMaxTime, tableName));
             }
         }
     }
 
-    private String formatExecutionTimeError(QueryInfo violation, long maxTime, int count, String tableName) {
+    private String formatExecutionTimeError(List<QueryInfo> violations, long maxTime, String tableName) {
         String prefix = tableName != null
             ? String.format("Table '%s' execution time", tableName)
             : "Query execution time";
 
-        return String.format(
-            "%s assertion failed: max=%dms, violations=%d\nFirst violation: %dms > %dms, type=%s\nSQL: %s",
-            prefix,
-            maxTime,
-            count,
-            violation.getExecutionTimeMs(),
-            maxTime,
-            violation.getQueryType(),
-            violation.getQuery()
-        );
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("%s assertion failed: max=%dms, violations=%d",
+            prefix, maxTime, violations.size()));
+
+        int reportCount = Math.min(violations.size(), MAX_VIOLATIONS_TO_REPORT);
+        for (int i = 0; i < reportCount; i++) {
+            QueryInfo violation = violations.get(i);
+            sb.append(String.format("\n[%d] %dms > %dms, type=%s, SQL: %s",
+                i + 1,
+                violation.getExecutionTimeMs(),
+                maxTime,
+                violation.getQueryType(),
+                violation.getQuery()));
+        }
+
+        if (violations.size() > MAX_VIOLATIONS_TO_REPORT) {
+            sb.append(String.format("\n... and %d more violations", violations.size() - MAX_VIOLATIONS_TO_REPORT));
+        }
+
+        return sb.toString();
     }
 
     private EnumMap<QueryType, Long> getActualCounts() {
@@ -183,7 +197,7 @@ class QueryCountVerifier {
                 ));
         }
         return cachedQueries.stream()
-            .filter(queryInfo -> !Collections.disjoint(queryInfo.getTableNames(), tableNames))
+            .filter(this::hasTableOverlap)
             .collect(Collectors.groupingBy(
                 QueryInfo::getQueryType,
                 () -> new EnumMap<>(QueryType.class),
@@ -201,9 +215,16 @@ class QueryCountVerifier {
         }
 
         return cachedQueries.stream()
-            .filter(q -> !hasTableFilter || !Collections.disjoint(q.getTableNames(), tableNames))
+            .filter(q -> !hasTableFilter || hasTableOverlap(q))
             .filter(q -> !hasTypeFilter || types.contains(q.getQueryType()))
             .collect(Collectors.toList());
+    }
+
+    /**
+     * 쿼리가 필터링 대상 테이블과 공통 테이블을 가지는지 확인
+     */
+    private boolean hasTableOverlap(QueryInfo queryInfo) {
+        return queryInfo.getTableNames().stream().anyMatch(tableNames::contains);
     }
 
 }

--- a/src/main/java/soon/springtestutil/querycount/assertion/QueryCountVerifier.java
+++ b/src/main/java/soon/springtestutil/querycount/assertion/QueryCountVerifier.java
@@ -41,14 +41,13 @@ class QueryCountVerifier {
         if (!errors.isEmpty()) {
             throw new AssertionError(TestContextHolder.getContextInfo() + String.join("\n\n", errors));
         }
-
-        verifyExecutionTimes();
     }
 
     private List<String> collectErrors() {
         List<String> errors = new ArrayList<>();
         verifyQueryCounts(errors);
         verifyTableQueryCounts(errors);
+        collectExecutionTimeErrors(errors);
         return errors;
     }
 
@@ -114,12 +113,12 @@ class QueryCountVerifier {
         return errors;
     }
 
-    private void verifyExecutionTimes() {
-        verifyGlobalExecutionTime();
-        verifyTableExecutionTime();
+    private void collectExecutionTimeErrors(List<String> errors) {
+        collectGlobalExecutionTimeErrors(errors);
+        collectTableExecutionTimeErrors(errors);
     }
 
-    private void verifyGlobalExecutionTime() {
+    private void collectGlobalExecutionTimeErrors(List<String> errors) {
         if (maxExecutionTimeMs == null) {
             return;
         }
@@ -129,12 +128,11 @@ class QueryCountVerifier {
             .toList();
 
         if (!violations.isEmpty()) {
-            throw createExecutionTimeError(violations.get(0), maxExecutionTimeMs, violations.size(), null);
+            errors.add(formatExecutionTimeError(violations.get(0), maxExecutionTimeMs, violations.size(), null));
         }
     }
 
-    private void verifyTableExecutionTime() {
-
+    private void collectTableExecutionTimeErrors(List<String> errors) {
         for (TableQueryAssertion tableAssertion : tableAssertions.values()) {
             Long tableMaxTime = tableAssertion.getMaxExecutionTimeMs();
             if (tableMaxTime == null) {
@@ -153,19 +151,18 @@ class QueryCountVerifier {
                 .toList();
 
             if (!violations.isEmpty()) {
-                throw createExecutionTimeError(violations.get(0), tableMaxTime, violations.size(), tableName);
+                errors.add(formatExecutionTimeError(violations.get(0), tableMaxTime, violations.size(), tableName));
             }
         }
     }
 
-    private AssertionError createExecutionTimeError(QueryInfo violation, long maxTime, int count, String tableName) {
+    private String formatExecutionTimeError(QueryInfo violation, long maxTime, int count, String tableName) {
         String prefix = tableName != null
             ? String.format("Table '%s' execution time", tableName)
             : "Query execution time";
 
-        String message = String.format(
-            "%s%s assertion failed: max=%dms, violations=%d\nFirst violation: %dms > %dms, type=%s\nSQL: %s",
-            TestContextHolder.getContextInfo(),
+        return String.format(
+            "%s assertion failed: max=%dms, violations=%d\nFirst violation: %dms > %dms, type=%s\nSQL: %s",
             prefix,
             maxTime,
             count,
@@ -174,7 +171,6 @@ class QueryCountVerifier {
             violation.getQueryType(),
             violation.getQuery()
         );
-        return new AssertionError(message);
     }
 
     private EnumMap<QueryType, Long> getActualCounts() {

--- a/src/main/java/soon/springtestutil/querycount/assertion/QueryCounterAssertion.java
+++ b/src/main/java/soon/springtestutil/querycount/assertion/QueryCounterAssertion.java
@@ -1,16 +1,17 @@
 package soon.springtestutil.querycount.assertion;
 
-import soon.springtestutil.core.context.TestContextHolder;
 import soon.springtestutil.querycount.QueryType;
 import soon.springtestutil.querycount.context.QueryCountContext;
-import soon.springtestutil.querycount.context.QueryInfo;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
+/**
+ * 쿼리 카운트 검증을 위한 빌더 클래스
+ */
 public class QueryCounterAssertion {
 
     private final Map<QueryType, Long> expectedCounts = new EnumMap<>(QueryType.class);
+    private final Map<String, TableQueryAssertion> tableAssertions = new LinkedHashMap<>();
     private Set<String> tableNames;
     private Long maxExecutionTimeMs;
 
@@ -21,6 +22,26 @@ public class QueryCounterAssertion {
         return new QueryCounterAssertion();
     }
 
+    /**
+     * 특정 테이블에 대한 쿼리 카운트 검증 조건을 설정합니다.
+     * 체이닝을 통해 여러 테이블에 대해 각각 다른 검증 조건을 설정할 수 있습니다.
+     *
+     * <pre>{@code
+     * QueryCounterAssertion.assertCounts()
+     *     .forTable("member").insert(2).select(1)
+     *     .forTable("product").select(3)
+     *     .verify();
+     * }</pre>
+     */
+    public TableQueryAssertion forTable(String tableName) {
+        return tableAssertions.computeIfAbsent(tableName,
+            name -> new TableQueryAssertion(this, name));
+    }
+
+    /**
+     * 여러 테이블에 대한 통합 쿼리 카운트 검증 조건을 설정합니다.
+     * 지정된 모든 테이블에서 발생한 쿼리의 총 합계를 검증합니다.
+     */
     public QueryCounterAssertion forTables(String... tableNames) {
         this.tableNames = new HashSet<>(Arrays.asList(tableNames));
         return this;
@@ -56,91 +77,23 @@ public class QueryCounterAssertion {
         return this;
     }
 
-    // TODO: 현재는 각 쿼리별 측정, 통합 실행 시간 측정 기능 추가
     public QueryCounterAssertion maxExecutionTimeMs(long maxExecutionTimeMs) {
         this.maxExecutionTimeMs = maxExecutionTimeMs;
         return this;
     }
 
     public void verify() {
-        EnumMap<QueryType, Long> actualCounts = getActualCounts();
-
-        String errors = expectedCounts.keySet().stream()
-            .map(type -> {
-                long expected = expectedCounts.get(type);
-                long actual = actualCounts.getOrDefault(type, 0L);
-                if (expected != actual) {
-                    return String.format("QueryType.%s: expected %d, but was %d", type, expected,
-                        actual);
-                }
-                return null;
-            })
-            .filter(Objects::nonNull)
-            .collect(Collectors.joining("\n"));
-
-        if (!errors.isEmpty()) {
+        try {
+            QueryCountVerifier verifier = new QueryCountVerifier(
+                expectedCounts,
+                tableAssertions,
+                tableNames,
+                maxExecutionTimeMs
+            );
+            verifier.verify();
+        } finally {
             QueryCountContext.clear();
-
-            String contextInfo = TestContextHolder.getContextInfo();
-            throw new AssertionError(contextInfo + "Query count assertion failed:\n" + errors);
         }
-
-        if (maxExecutionTimeMs != null) {
-            List<QueryInfo> filtered = getFilteredQueriesForTimeCheck();
-            List<QueryInfo> violations = filtered.stream()
-                .filter(q -> q.getExecutionTimeMs() != null && q.getExecutionTimeMs() > maxExecutionTimeMs)
-                .toList();
-
-            if (!violations.isEmpty()) {
-                QueryInfo first = violations.get(0);
-                String contextInfo = TestContextHolder.getContextInfo();
-                QueryCountContext.clear();
-                String message = String.format(
-                    "%sQuery execution time assertion failed: max=%dms, violations=%d\nFirst violation: %dms > %dms, type=%s\nSQL: %s",
-                    contextInfo,
-                    maxExecutionTimeMs,
-                    violations.size(),
-                    first.getExecutionTimeMs(),
-                    maxExecutionTimeMs,
-                    first.getQueryType(),
-                    first.getQuery()
-                );
-                throw new AssertionError(message);
-            }
-        }
-
-        QueryCountContext.clear();
-    }
-
-    private EnumMap<QueryType, Long> getActualCounts() {
-        if (tableNames == null || tableNames.isEmpty()) {
-            return QueryCountContext.getQueryCounts();
-        }
-        return QueryCountContext.getQueries().stream()
-            .filter(queryInfo -> !Collections.disjoint(queryInfo.getTableNames(), tableNames))
-            .collect(Collectors.groupingBy(
-                QueryInfo::getQueryType,
-                () -> new EnumMap<>(QueryType.class),
-                Collectors.counting()
-            ));
-    }
-
-    private List<QueryInfo> getFilteredQueriesForTimeCheck() {
-        List<QueryInfo> base = QueryCountContext.getQueries();
-        if (tableNames != null && !tableNames.isEmpty()) {
-            base = base.stream()
-                .filter(q -> !Collections.disjoint(q.getTableNames(), tableNames))
-                .collect(Collectors.toList());
-        }
-
-        if (!expectedCounts.isEmpty()) {
-            Set<QueryType> types = expectedCounts.keySet();
-            base = base.stream()
-                .filter(q -> types.contains(q.getQueryType()))
-                .collect(Collectors.toList());
-        }
-
-        return base;
     }
 
 }

--- a/src/main/java/soon/springtestutil/querycount/assertion/TableQueryAssertion.java
+++ b/src/main/java/soon/springtestutil/querycount/assertion/TableQueryAssertion.java
@@ -1,0 +1,86 @@
+package soon.springtestutil.querycount.assertion;
+
+import soon.springtestutil.querycount.QueryType;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * 특정 테이블에 대한 쿼리 카운트 검증 조건을 저장하는 클래스입니다.
+ */
+public class TableQueryAssertion {
+
+    private final QueryCounterAssertion parent;
+    private final String tableName;
+    private final Map<QueryType, Long> expectedCounts = new EnumMap<>(QueryType.class);
+    private Long maxExecutionTimeMs;
+
+    TableQueryAssertion(QueryCounterAssertion parent, String tableName) {
+        this.parent = parent;
+        this.tableName = tableName;
+    }
+
+    public TableQueryAssertion select(long count) {
+        expectedCounts.put(QueryType.SELECT, count);
+        return this;
+    }
+
+    public TableQueryAssertion insert(long count) {
+        expectedCounts.put(QueryType.INSERT, count);
+        return this;
+    }
+
+    public TableQueryAssertion update(long count) {
+        expectedCounts.put(QueryType.UPDATE, count);
+        return this;
+    }
+
+    public TableQueryAssertion delete(long count) {
+        expectedCounts.put(QueryType.DELETE, count);
+        return this;
+    }
+
+    public TableQueryAssertion others(long count) {
+        expectedCounts.put(QueryType.OTHERS, count);
+        return this;
+    }
+
+    public TableQueryAssertion maxExecutionTimeMs(long maxExecutionTimeMs) {
+        this.maxExecutionTimeMs = maxExecutionTimeMs;
+        return this;
+    }
+
+    /**
+     * 다른 테이블에 대한 검증 조건을 추가합니다.
+     */
+    public TableQueryAssertion forTable(String tableName) {
+        return parent.forTable(tableName);
+    }
+
+    /**
+     * 여러 테이블에 대한 통합 검증 조건을 추가합니다.
+     */
+    public QueryCounterAssertion forTables(String... tableNames) {
+        return parent.forTables(tableNames);
+    }
+
+    /**
+     * 모든 검증을 수행합니다.
+     */
+    public void verify() {
+        parent.verify();
+    }
+
+    String getTableName() {
+        return tableName;
+    }
+
+    Map<QueryType, Long> getExpectedCounts() {
+        return expectedCounts;
+    }
+
+    Long getMaxExecutionTimeMs() {
+        return maxExecutionTimeMs;
+    }
+
+}

--- a/src/main/java/soon/springtestutil/querycount/assertion/TableQueryAssertion.java
+++ b/src/main/java/soon/springtestutil/querycount/assertion/TableQueryAssertion.java
@@ -1,5 +1,6 @@
 package soon.springtestutil.querycount.assertion;
 
+import org.springframework.util.StringUtils;
 import soon.springtestutil.querycount.QueryType;
 
 import java.util.EnumMap;
@@ -16,6 +17,12 @@ public class TableQueryAssertion {
     private Long maxExecutionTimeMs;
 
     TableQueryAssertion(QueryCounterAssertion parent, String tableName) {
+        if (parent == null) {
+            throw new IllegalArgumentException("parent must not be null");
+        }
+        if (!StringUtils.hasText(tableName)) {
+            throw new IllegalArgumentException("tableName must not be null or blank");
+        }
         this.parent = parent;
         this.tableName = tableName;
     }

--- a/src/test/java/soon/springtestutil/core/context/TestContextHolderTest.java
+++ b/src/test/java/soon/springtestutil/core/context/TestContextHolderTest.java
@@ -1,13 +1,14 @@
 package soon.springtestutil.core.context;
 
-import static java.util.concurrent.Executors.newFixedThreadPool;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class TestContextHolderTest {
 
@@ -22,7 +23,7 @@ class TestContextHolderTest {
         // given
         String className = "com.example.TestContextHolderTest";
         String methodName = "contextInfoSelected";
-        String expected = "[Test: %s#%s]".formatted(className, methodName);
+        String expected = "[Test: %s#%s] ".formatted(className, methodName);
 
         // when
         TestContextHolder.setContext(className, methodName);
@@ -33,15 +34,15 @@ class TestContextHolderTest {
             .isEqualTo(expected);
     }
 
-    @DisplayName("컨텍스트 정보가 설정되지 않은 경우 Unknown이 반환된다.")
+    @DisplayName("컨텍스트 정보가 설정되지 않은 경우 빈 문자열이 반환된다.")
     @Test
-    void contextInfoReturnsUnknownWhenNotSet() {
+    void contextInfoReturnsEmptyWhenNotSet() {
         // given
         String contextInfo = TestContextHolder.getContextInfo();
 
         // expected
         assertThat(contextInfo)
-            .isEqualTo("[Test: Unknown]");
+            .isEmpty();
     }
 
     @DisplayName("여러 스레드에서 컨텍스트 정보는 격리된다.")
@@ -63,7 +64,7 @@ class TestContextHolderTest {
                 String contextInfo = TestContextHolder.getContextInfo();
 
                 assertThat(contextInfo)
-                    .isEqualTo("[Test: %s#%s]".formatted(thread1ClassName, thread1MethodName));
+                    .isEqualTo("[Test: %s#%s] ".formatted(thread1ClassName, thread1MethodName));
             } finally {
                 latch.countDown();
             }
@@ -75,7 +76,7 @@ class TestContextHolderTest {
                 String contextInfo = TestContextHolder.getContextInfo();
 
                 assertThat(contextInfo)
-                    .isEqualTo("[Test: %s#%s]".formatted(thread2ClassName, thread2MethodName));
+                    .isEqualTo("[Test: %s#%s] ".formatted(thread2ClassName, thread2MethodName));
             } finally {
                 latch.countDown();
             }
@@ -85,7 +86,7 @@ class TestContextHolderTest {
         executorService.shutdown();
 
         assertThat(TestContextHolder.getContextInfo())
-            .isEqualTo("[Test: Unknown]");
+            .isEmpty();
     }
 
 }

--- a/src/test/java/soon/springtestutil/querycount/assertion/QueryCountAssertionIntegrationTest.java
+++ b/src/test/java/soon/springtestutil/querycount/assertion/QueryCountAssertionIntegrationTest.java
@@ -1,6 +1,5 @@
 package soon.springtestutil.querycount.assertion;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,7 +9,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import soon.springtestutil.config.AutoConfig;
-import soon.springtestutil.querycount.QueryType;
 import soon.springtestutil.querycount.context.QueryCountContext;
 import soon.springtestutil.querycount.extension.QueryCountTestExtension;
 
@@ -24,11 +22,6 @@ public class QueryCountAssertionIntegrationTest {
     @Autowired
     JdbcTemplate jdbcTemplate;
 
-    @AfterEach
-    void tearDown() {
-        QueryCountContext.clear();
-    }
-
     @BeforeEach
     void initSchema() {
         jdbcTemplate.execute("DROP TABLE IF EXISTS orders");
@@ -40,70 +33,7 @@ public class QueryCountAssertionIntegrationTest {
     }
 
     @Test
-    @DisplayName("SELECT 카운트가 예상과 일치한다.")
-    void verifySelectCountSuccess() {
-        // given
-        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 20L);
-        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 25L);
-
-        // expected
-        QueryCounterAssertion.assertCounts()
-            .select(2)
-            .verify();
-    }
-
-    @Test
-    @DisplayName("여러 테이블 지정시 지정된 테이블 관련 쿼리만 카운트된다")
-    void multipleTablesFiltering() {
-        // given
-        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 30L);
-        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM orders", 40L);
-        QueryCountContext.addQuery(QueryType.SELECT, "SELECT m.id, o.id FROM member m JOIN orders o ON m.id = o.member_id", 50L);
-        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM product", 35L); // 제외
-
-        // expected
-        QueryCounterAssertion.assertCounts()
-            .forTables("member", "orders")
-            .select(3)
-            .verify();
-    }
-
-    @Test
-    @DisplayName("개별 쿼리 실행 시간이 한도를 초과하면 실패한다")
-    void failsWhenPerQueryExecutionTimeExceeded() {
-        // given
-        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 120L);
-        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 80L);
-
-        // expected
-        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
-            .maxExecutionTimeMs(100)
-            .select(2)
-            .verify()
-        )
-            .isInstanceOf(AssertionError.class)
-            .hasMessageContaining("Query execution time assertion failed")
-            .hasMessageContaining("violations=");
-    }
-
-    @Test
-    @DisplayName("예상 카운트와 실제 카운트가 다르면 실패한다")
-    void failsWhenCountMismatch() {
-        // given
-        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 10L);
-
-        // expected
-        assertThatThrownBy(() ->
-            QueryCounterAssertion.assertCounts()
-                .select(2)
-                .verify()
-        )
-            .isInstanceOf(AssertionError.class)
-            .hasMessageContaining("expected 2, but was 1");
-    }
-
-    @Test
-    @DisplayName("maxExecutionTime(ms)를 초과한 쿼리는 실패한다")
+    @DisplayName("실제 DB 쿼리 실행 시 maxExecutionTime(ms)를 초과하면 실패한다")
     void verifyMaxExecutionTimeShouldFailWhenExceeded() {
         // given
         jdbcTemplate.execute("CALL SLEEP(120)");

--- a/src/test/java/soon/springtestutil/querycount/assertion/QueryCounterAssertionTest.java
+++ b/src/test/java/soon/springtestutil/querycount/assertion/QueryCounterAssertionTest.java
@@ -10,6 +10,7 @@ import soon.springtestutil.querycount.extension.QueryCountTestExtension;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(QueryCountTestExtension.class)
@@ -62,22 +63,16 @@ class QueryCounterAssertionTest {
         QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (2, 'test2')");
         QueryCountContext.addQuery(QueryType.UPDATE, "UPDATE member SET name = 'test' WHERE id = 1");
 
-        // expected
+        // expected - SELECT만 지정하면 INSERT, UPDATE는 검증하지 않음
         QueryCounterAssertion.assertCounts()
             .select(1)
             .verify();
-    }
 
-    @DisplayName("여러 타입 중 일부만 지정하면, 지정한 타입만 검증한다.")
-    @Test
-    void verifyShouldCheckOnlySpecifiedTypes() {
-        // given
+        // INSERT만 지정해도 동일하게 동작
         QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
         QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (1, 'test')");
         QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id, name) VALUES (2, 'test2')");
-        QueryCountContext.addQuery(QueryType.UPDATE, "UPDATE member SET name = 'test' WHERE id = 1");
 
-        // expected
         QueryCounterAssertion.assertCounts()
             .insert(2)
             .verify();
@@ -209,6 +204,190 @@ class QueryCounterAssertionTest {
             .maxExecutionTimeMs(100)
             .select(3)
             .verify();
+    }
+
+    @Test
+    @DisplayName("forTable 검증에서 쿼리 횟수가 일치하지 않으면 예외가 발생한다.")
+    void forTableShouldFailWhenCountsDoNotMatch() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO product (id, name) VALUES (1, 'test')");
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .forTable("member").select(2)
+            .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Table 'member' - QueryType.SELECT: expected 2, but was 1");
+    }
+
+
+    @Test
+    @DisplayName("forTable과 forTables를 함께 사용할 수 있다.")
+    void forTableAndForTablesShouldWorkTogether() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM orders");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO product (id, name) VALUES (1, 'test')");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO product (id, name) VALUES (2, 'test2')");
+
+        // expected - forTables로 member, orders 합계 검증 + forTable로 product 개별 검증
+        QueryCounterAssertion.assertCounts()
+            .forTables("member", "orders")
+            .select(2)
+            .forTable("product").insert(2)
+            .verify();
+    }
+
+
+    @Test
+    @DisplayName("UPDATE 쿼리 횟수가 예상과 다르면 예외가 발생한다.")
+    void verifyShouldFailWhenUpdateCountDoesNotMatch() {
+        // given
+        QueryCountContext.addQuery(QueryType.UPDATE, "UPDATE member SET name = 'test' WHERE id = 1");
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .update(2)
+            .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("QueryType.UPDATE: expected 2, but was 1");
+    }
+
+
+    @Test
+    @DisplayName("DELETE 쿼리 횟수가 예상과 다르면 예외가 발생한다.")
+    void verifyShouldFailWhenDeleteCountDoesNotMatch() {
+        // given
+        QueryCountContext.addQuery(QueryType.DELETE, "DELETE FROM member WHERE id = 1");
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .delete(2)
+            .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("QueryType.DELETE: expected 2, but was 1");
+    }
+
+
+    @Test
+    @DisplayName("OTHERS 쿼리 횟수가 예상과 다르면 예외가 발생한다.")
+    void verifyShouldFailWhenOthersCountDoesNotMatch() {
+        // given
+        QueryCountContext.addQuery(QueryType.OTHERS, "CREATE TABLE test (id INT)");
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .others(2)
+            .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("QueryType.OTHERS: expected 2, but was 1");
+    }
+
+    @Test
+    @DisplayName("아무 조건도 설정하지 않으면 검증 없이 통과한다.")
+    void verifyShouldPassWithNoConditions() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id) VALUES (1)");
+
+        // expected
+        QueryCounterAssertion.assertCounts().verify();
+    }
+
+    @Test
+    @DisplayName("쿼리가 없을 때 0 카운트 검증이 통과한다.")
+    void verifyShouldPassWithZeroCountWhenNoQueries() {
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .select(0)
+            .insert(0)
+            .update(0)
+            .delete(0)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("여러 쿼리 타입의 카운트 불일치 시 모든 오류가 메시지에 포함된다.")
+    void verifyShouldIncludeAllMismatchesInErrorMessage() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id) VALUES (1)");
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .select(2)
+            .insert(2)
+            .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("QueryType.SELECT: expected 2, but was 1")
+            .hasMessageContaining("QueryType.INSERT: expected 2, but was 1");
+    }
+
+    @Test
+    @DisplayName("verify 후 QueryCountContext가 초기화된다.")
+    void verifyShouldClearContextAfterExecution() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+
+        // when
+        QueryCounterAssertion.assertCounts().select(1).verify();
+
+        // then
+        assertThat(QueryCountContext.getQueries()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("verify 실패 후에도 QueryCountContext가 초기화된다.")
+    void verifyShouldClearContextEvenOnFailure() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+
+        // when
+        try {
+            QueryCounterAssertion.assertCounts().select(2).verify();
+        } catch (AssertionError ignored) {
+        }
+
+        // then
+        assertThat(QueryCountContext.getQueries()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("forTables에 빈 리스트를 전달하면 전체 쿼리를 검증한다.")
+    void forTablesWithEmptyListShouldVerifyAllQueries() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM product");
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .forTables(List.of())
+            .select(2)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("복합 조건에서 카운트 오류와 테이블별 오류가 모두 포함된다.")
+    void verifyShouldIncludeBothGlobalAndTableErrors() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM product");
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .select(3)
+            .forTable("member").insert(1)
+            .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("QueryType.SELECT: expected 3, but was 2")
+            .hasMessageContaining("Table 'member' - QueryType.INSERT: expected 1, but was 0");
     }
 
 }

--- a/src/test/java/soon/springtestutil/querycount/assertion/TableQueryAssertionTest.java
+++ b/src/test/java/soon/springtestutil/querycount/assertion/TableQueryAssertionTest.java
@@ -1,0 +1,119 @@
+package soon.springtestutil.querycount.assertion;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import soon.springtestutil.querycount.QueryType;
+import soon.springtestutil.querycount.context.QueryCountContext;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TableQueryAssertionTest {
+
+    @AfterEach
+    void tearDown() {
+        QueryCountContext.clear();
+    }
+
+    @Test
+    @DisplayName("TableQueryAssertion은 체이닝을 통해 여러 쿼리 타입을 설정할 수 있다")
+    void shouldSupportMethodChaining() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO member (id) VALUES (1)");
+        QueryCountContext.addQuery(QueryType.UPDATE, "UPDATE member SET name='test'");
+        QueryCountContext.addQuery(QueryType.DELETE, "DELETE FROM member WHERE id=1");
+
+        // expected
+        QueryCounterAssertion.assertCounts().forTable("member")
+            .select(1)
+            .insert(1)
+            .update(1)
+            .delete(1)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("동일 테이블을 여러 번 참조해도 마지막 설정이 적용된다")
+    void shouldUseLastSettingForSameTable() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .forTable("member").select(1)
+            .forTable("member").select(2)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("others 쿼리 타입을 검증할 수 있다")
+    void shouldVerifyOthersQueryType() {
+        // given
+        QueryCountContext.addQuery(QueryType.OTHERS, "TRUNCATE TABLE test");
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .others(1)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("테이블별 maxExecutionTimeMs 설정이 독립적으로 적용된다")
+    void shouldApplyMaxExecutionTimeIndependentlyPerTable() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 80L);
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM product", 150L);
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .forTable("member").select(1).maxExecutionTimeMs(100)
+            .forTable("product").select(1).maxExecutionTimeMs(200)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("테이블별 maxExecutionTimeMs 초과 시 해당 테이블 정보가 에러에 포함된다")
+    void shouldIncludeTableNameInExecutionTimeError() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 150L);
+
+        // expected
+        assertThatThrownBy(() -> QueryCounterAssertion.assertCounts()
+            .forTable("member").select(1).maxExecutionTimeMs(100)
+            .verify()
+        )
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("Table 'member'")
+            .hasMessageContaining("execution time assertion failed");
+    }
+
+    @Test
+    @DisplayName("forTable에서 forTables로 전환할 수 있다")
+    void shouldSwitchFromForTableToForTables() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member");
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM orders");
+        QueryCountContext.addQuery(QueryType.INSERT, "INSERT INTO product (id) VALUES (1)");
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .forTable("product").insert(1)
+            .forTables("member", "orders").select(2)
+            .verify();
+    }
+
+    @Test
+    @DisplayName("쿼리 카운트 없이 maxExecutionTimeMs만 설정해도 검증된다")
+    void shouldVerifyOnlyExecutionTimeWithoutCount() {
+        // given
+        QueryCountContext.addQuery(QueryType.SELECT, "SELECT * FROM member", 50L);
+
+        // expected
+        QueryCounterAssertion.assertCounts()
+            .forTable("member").maxExecutionTimeMs(100)
+            .verify();
+    }
+
+}


### PR DESCRIPTION
## Pull Request

### Related Issue
- Resolved: #48 

### Summary
각 테이블 별로 쿼리를 지정 할 수 있도록 수정
<!-- 어던 변경을 했는지 작성 -->

### Details
- 기존의 모호한 에러 메시지를 수정
- TableQueryAssertions 클래스 추가로 테이블 별 쿼리 검증
- QueryCountVerifier 클래스 추가로 쿼리 검증 로직 분리
- 기존의 모호하고 필요 없던 테스트 수정
<!-- 변경 사항을 구체적으로 작성 -->


### ETC
```java
QueryCounterAssertion.assertCounts()
    .forTables("member").insert(1)             // member 테이블은 INSERT 1회
    .forTables("product").select(2).update(1)  // product 테이블은 SELECT 2회, UPDATE 1회
    .maxExecutionTimeMs(150)                   // 전체 쿼리 실행 시간 검증
    .verify();
```
<!-- 기타 참고사항 작성 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-table query validation API: chainable forTable/forTables to assert per-table counts and per-table max execution times.
* **Documentation**
  * README and changelog updated with examples and clearer failure messages for per-table assertions and execution-time violations.
* **Tests**
  * Added and expanded tests covering per-table counts, per-table execution-time checks, combined/global scenarios, and mismatch/error cases.
* **Other**
  * Test context formatting adjusted to change empty/unknown context handling in messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->